### PR TITLE
Removed annoying slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM nfcore/base
 
 LABEL authors="harshil.patel@crick.ac.uk" \
     maintainer="harshil.patel@crick.ac.uk" \
-    description="Docker image containing all requirements for the nfcore/atacseq pipeline" \
+    description="Docker image containing all requirements for the nfcore/atacseq pipeline"
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a


### PR DESCRIPTION

Docker build was failing due to slash at the end of the `LABEL` field. Just removed this to rebuild.