### PR TITLE
Missing flag in computeMatrix caused sparse data to return black plots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+* [#139](https://github.com/nf-core/atacseq/issues/139) - mergedLibray plotHeatmap returning black graph
+
 ### `Dependencies`
 
 ## [1.2.1] - 2020-07-29

--- a/main.nf
+++ b/main.nf
@@ -1049,6 +1049,7 @@ process MERGED_LIB_PLOTPROFILE {
         --afterRegionStartLength 3000 \\
         --skipZeros \\
         --smartLabels \\
+        --missingDataAsZero \\
         --numberOfProcessors $task.cpus
 
     plotProfile --matrixFile ${prefix}.computeMatrix.mat.gz \\


### PR DESCRIPTION
# nf-core/atacseq pull request

Many thanks for contributing to nf-core/atacseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [X] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)

Added the flag `--missingDataAsZero` in the `computeMatrix` function in order to avoid the heatmaps to be fully black.