### PR TITLE
Multiqc fail

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -12,6 +12,9 @@ jobs:
     name: Run AWS full tests
     if: github.repository == 'nf-core/atacseq'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        aligner: ["bwa", "bowtie2", "chromap", "star"]
     steps:
       - name: Launch workflow via tower
         uses: nf-core/tower-action@v3
@@ -23,6 +26,7 @@ jobs:
           parameters: |
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/atacseq/results-${{ github.sha }}"
+              "aligner": "${{ matrix.aligner }}"
             }
           profiles: test_full,aws_tower
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,26 @@ jobs:
       - name: Run pipeline with various parameters
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.parameters }} --outdir ./results
+
+  aligners:
+    name: Test available aligners
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/atacseq') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        aligner:
+          - "bowtie2"
+          - "chromap"
+          - "star"
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Run pipeline with the different aligners available
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner ${{ matrix.aligner }} --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[201](https://github.com/nf-core/atacseq/issues/201)] - Update blacklist bed files.
 - [[182](https://github.com/nf-core/atacseq/issues/182)] - Update `macs_gsize` in `igenomes.config`, create a new `--read_length` parameter and implement the logic to calculate `--macs_gsize` when the parameter is missing.
 - Turn `--deseq2_vst` on by default
+- [[#233](https://github.com/nf-core/chipseq/issues/233)] - Add `chromap` to the available aligners
+- [[#160](https://github.com/nf-core/chipseq/issues/160)] - Add `bowtie2` and `star` as available aligners, via the `--aligner` parameter
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Port pipeline to the updated Nextflow DSL2 syntax adopted on nf-core/modules
 - Bump minimum Nextflow version from `19.10.0` -> `21.10.3`
 - [[201](https://github.com/nf-core/atacseq/issues/201)] - Update blacklist bed files.
-- [[182](https://github.com/nf-core/atacseq/issues/182)] - Update `macs_gsize` in `igenomes.config`, create a new `--read_length` parameter and implement the logic to calculate `--macs_gsize` when the parameter is missing.
+- [[182](https://github.com/nf-core/atacseq/issues/182)] - Update `macs_gsize` in `igenomes.config`, create a new `--read_length` parameter and implement the logic to calculate `--macs_gsize` when the parameter is missing
 - Turn `--deseq2_vst` on by default
 - [[#233](https://github.com/nf-core/chipseq/issues/233)] - Add `chromap` to the available aligners
 - [[#160](https://github.com/nf-core/chipseq/issues/160)] - Add `bowtie2` and `star` as available aligners, via the `--aligner` parameter
+- Add `--save_unaligned` parameter (only available for `bowtie2` and `star`)
 
 ### Parameters
 
@@ -25,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `--conda`              | `--enable_conda`   |
 |                        | `--skip_qc`        |
 |                        | `--aligner`        |
+|                        | `--save_unaligned` |
+|                        | `--bowtie2_index`  |
+|                        | `--chromap_index`  |
+|                        | `--star_index`     |
 | `--skip_diff_analysis` | `--skip_deseq2_qc` |
 | `--single_end`         |                    |
 |                        | `--read_length`    |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unpublished Version / DEV]
 
+- Fix channels supplying Homer inputs to MultiQC
 ### Major enhancements
 
 - Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 1. Raw read QC ([`FastQC`](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
 2. Adapter trimming ([`Trim Galore!`](https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/))
-3. Alignment ([`BWA`](https://sourceforge.net/projects/bio-bwa/files/))
+3. Choice of multiple aligners
+   1.([`BWA`](https://sourceforge.net/projects/bio-bwa/files/))
+   2.([`Chromap`](https://github.com/haowenz/chromap)). **For paired-end reads only working until mapping steps, see [here](https://github.com/nf-core/chipseq/issues/291)**
+   3.([`Bowtie2`](http://bowtie-bio.sourceforge.net/bowtie2/index.shtml))
+   4.([`STAR`](https://github.com/alexdobin/STAR))
 4. Mark duplicates ([`picard`](https://broadinstitute.github.io/picard/))
 5. Merge alignments from multiple libraries of the same sample ([`picard`](https://broadinstitute.github.io/picard/))
    1. Re-mark duplicates ([`picard`](https://broadinstitute.github.io/picard/))

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The nf-core/atacseq pipeline comes with documentation about the pipeline [usage]
 
 ## Credits
 
-The pipeline was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [Seqera Labs, Spain](https://seqera.io/) and converted to Nextflow DSL2 by Björn Langer ([@bjlang](https://github.com/bjlang)) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/).
+The pipeline was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [Seqera Labs, Spain](https://seqera.io/) and converted to Nextflow DSL2 by Björn Langer ([@bjlang](https://github.com/bjlang)) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/) under the umbrella of the [BovReg project](https://www.bovreg.eu/).
 
 Many thanks to others who have helped out and contributed along the way too, including (but not limited to): [@ewels](https://github.com/ewels), [@apeltzer](https://github.com/apeltzer), [@crickbabs](https://github.com/crickbabs), [drewjbeh](https://github.com/drewjbeh), [@houghtos](https://github.com/houghtos), [@jinmingda](https://github.com/jinmingda), [@ktrns](https://github.com/ktrns), [@MaxUlysse](https://github.com/MaxUlysse), [@mashehu](https://github.com/mashehu), [@micans](https://github.com/micans), [@pditommaso](https://github.com/pditommaso) and [@sven1103](https://github.com/sven1103).
 

--- a/assets/test.csv
+++ b/assets/test.csv
@@ -1,5 +1,0 @@
-sample,fastq_1,fastq_2
-OSMOTIC_STRESS_T0_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822153_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822153_2.fastq.gz
-OSMOTIC_STRESS_T0_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822154_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822154_2.fastq.gz
-OSMOTIC_STRESS_T15_REP1,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822157_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822157_2.fastq.gz
-OSMOTIC_STRESS_T15_REP2,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822158_1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/testdata/SRR1822158_2.fastq.gz

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -235,6 +235,88 @@ if (params.aligner == 'bwa') {
     }
 }
 
+if (params.aligner == 'bowtie2') {
+    process {
+        withName: 'BOWTIE2_ALIGN' {
+            ext.args   = ''
+            ext.prefix = { "${meta.id}.Lb" }
+            publishDir = [
+                [
+                    path: { "${params.outdir}/${params.aligner}/library" },
+                    mode: params.publish_dir_mode,
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+                    enabled: false
+                ],
+                [
+                    path: { "${params.outdir}/${params.aligner}/library/unmapped" },
+                    mode: params.publish_dir_mode,
+                    pattern: '*.fastq.gz',
+                    enabled: params.save_unaligned
+                ]
+            ]
+        }
+    }
+}
+
+if (params.aligner == 'chromap') {
+    process {
+        withName: CHROMAP_INDEX {
+            ext.args   = ''
+            publishDir = [
+                path: { "${params.outdir}/genome/${params.aligner}/index" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            ]
+        }
+        withName: CHROMAP_CHROMAP {
+            ext.args   = '-l 2000 --Tn5-shift --low-mem --SAM'
+            ext.prefix = { "${meta.id}.Lb" }
+            publishDir = [
+                path: { "${params.outdir}/${params.aligner}/library" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+                enabled: false
+            ]
+        }
+    }
+}
+
+if (params.aligner == 'star') {
+    process {
+        withName: '.*:ALIGN_STAR:STAR_ALIGN' {
+            ext.args   = [
+                '--runMode alignReads',
+                '--alignIntronMax 1',
+                '--alignEndsType EndToEnd',
+                '--outSAMtype BAM Unsorted',
+                '--readFilesCommand zcat',
+                '--runRNGseed 0',
+                '--outSAMattributes NH HI AS NM MD',
+                params.save_unaligned ? '--outReadsUnmapped Fastx' : ''
+            ].join(' ').trim()
+            publishDir = [
+                [
+                    path: { "${params.outdir}/${params.aligner}/library/log" },
+                    mode: params.publish_dir_mode,
+                    pattern: '*.{out,tab}'
+                ],
+                [
+                    path: { "${params.outdir}/${params.aligner}/library" },
+                    mode: params.publish_dir_mode,
+                    pattern: '*.bam',
+                    enabled: false
+                ],
+                [
+                    path: { "${params.outdir}/${params.aligner}/library/unmapped" },
+                    mode: params.publish_dir_mode,
+                    pattern: '*.fastq.gz',
+                    enabled: params.save_unaligned
+                ]
+            ]
+        }
+    }
+}
+
 process {
     withName: 'PICARD_MERGESAMFILES_LIB' {
         ext.args   = '--SORT_ORDER coordinate --VALIDATION_STRINGENCY LENIENT --TMP_DIR tmp'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -66,18 +66,9 @@ process {
         ]
     }
 
-    withName: 'BWA_INDEX|BOWTIE2_BUILD|STAR_GENOMEGENERATE' {
+    withName: 'BWA_INDEX|BOWTIE2_BUILD|STAR_GENOMEGENERATE|CHROMAP_INDEX' {
         publishDir = [
             path: { "${params.outdir}/genome/index" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            enabled: params.save_reference
-        ]
-    }
-
-    withName: 'UNTAR_CHROMAP_INDEX|CHROMAP_INDEX' {
-        publishDir = [
-            path: { "${params.outdir}/genome/index/chromap" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             enabled: params.save_reference

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -56,7 +56,7 @@ process {
         ext.args2 = '--no-same-owner'
     }
 
-    withName: 'UNTAR|BWA_INDEX' {
+    withName: 'BWA_INDEX|BOWTIE2_BUILD|STAR_GENOMEGENERATE' {
         publishDir = [
             path: { "${params.outdir}/genome/index" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -56,9 +56,28 @@ process {
         ext.args2 = '--no-same-owner'
     }
 
+    withName: 'UNTAR_.*' {
+        ext.args2 = '--no-same-owner'
+        publishDir = [
+            path: { "${params.outdir}/genome/index" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            enabled: params.save_reference
+        ]
+    }
+
     withName: 'BWA_INDEX|BOWTIE2_BUILD|STAR_GENOMEGENERATE' {
         publishDir = [
             path: { "${params.outdir}/genome/index" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            enabled: params.save_reference
+        ]
+    }
+
+    withName: 'UNTAR_CHROMAP_INDEX|CHROMAP_INDEX' {
+        publishDir = [
+            path: { "${params.outdir}/genome/index/chromap" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             enabled: params.save_reference
@@ -229,7 +248,8 @@ if (params.aligner == 'bwa') {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/library" },
                 mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+                enabled: false
             ]
         }
     }

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,8 +20,7 @@ params {
     max_time = 12.h
 
     // Input data
-    // input = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/design.csv'
-    input       = "$projectDir/assets/test.csv" // TODO delete file and push it to datesets
+    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/samplesheet/v2.0/samplesheet_test.csv'
     read_length = 50
 
     // Genome references

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,7 +15,7 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data
-    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/design_full.csv'
+    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/atacseq/samplesheet/v2.0/samplesheet_full.csv'
 
     // Used to calculate --macs_gsize
     read_length = 50

--- a/docs/output.md
+++ b/docs/output.md
@@ -62,7 +62,7 @@ The pipeline has been written in a way where all the files generated downstream 
 - `<ALIGNER>/library/samtools_stats/`
   - SAMtools `*.flagstat`, `*.idxstats` and `*.stats` files generated from the alignment files.
 
-> **NB:** File names in the resulting directory (i.e. `bwa/library/`) will have the '`.Lb.`' suffix.
+> **NB:** File names in the resulting directory (i.e. `<ALIGNER>/library/`) will have the '`.Lb.`' suffix.
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,23 +23,6 @@ CONTROL_REP1,AEG588A1_S1_L003_R1_001.fastq.gz,AEG588A1_S1_L003_R2_001.fastq.gz
 CONTROL_REP1,AEG588A1_S1_L004_R1_001.fastq.gz,AEG588A1_S1_L004_R2_001.fastq.gz
 ```
 
-### Multiple runs of the same library
-
-The `sample` identifiers have to be the same when you have re-sequenced the same sample more than once e.g. to increase sequencing depth. The pipeline will perform the alignments in parallel, and subsequently merge them before further analysis. Below is an example where the samples called `WT_BCATENIN_IP_REP2` and `WT_INPUT_REP2` have been re-sequenced multiple times:
-
-```console
-sample,fastq_1,fastq_2,antibody,control
-WT_BCATENIN_IP_REP1,BLA203A1_S27_L006_R1_001.fastq.gz,
-WT_BCATENIN_IP_REP2,BLA203A25_S16_L001_R1_001.fastq.gz,
-WT_BCATENIN_IP_REP2,BLA203A25_S16_L002_R1_001.fastq.gz,
-WT_BCATENIN_IP_REP2,BLA203A25_S16_L003_R1_001.fastq.gz,
-WT_BCATENIN_IP_REP3,BLA203A49_S40_L001_R1_001.fastq.gz,
-WT_INPUT_REP1,BLA203A6_S32_L006_R1_001.fastq.gz,
-WT_INPUT_REP2,BLA203A30_S21_L001_R1_001.fastq.gz,
-WT_INPUT_REP2,BLA203A30_S21_L002_R1_001.fastq.gz,
-WT_INPUT_REP3,BLA203A31_S21_L003_R1_001.fastq.gz,
-```
-
 ### Full samplesheet
 
 The pipeline will auto-detect whether a sample is single- or paired-end using the information provided in the samplesheet. The samplesheet can have as many columns as you desire, however, there is a strict requirement for the first 3 columns to match those defined in the table below.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,6 +23,23 @@ CONTROL_REP1,AEG588A1_S1_L003_R1_001.fastq.gz,AEG588A1_S1_L003_R2_001.fastq.gz
 CONTROL_REP1,AEG588A1_S1_L004_R1_001.fastq.gz,AEG588A1_S1_L004_R2_001.fastq.gz
 ```
 
+### Multiple runs of the same library
+
+The `sample` identifiers have to be the same when you have re-sequenced the same sample more than once e.g. to increase sequencing depth. The pipeline will perform the alignments in parallel, and subsequently merge them before further analysis. Below is an example where the samples called `WT_BCATENIN_IP_REP2` and `WT_INPUT_REP2` have been re-sequenced multiple times:
+
+```console
+sample,fastq_1,fastq_2,antibody,control
+WT_BCATENIN_IP_REP1,BLA203A1_S27_L006_R1_001.fastq.gz,
+WT_BCATENIN_IP_REP2,BLA203A25_S16_L001_R1_001.fastq.gz,
+WT_BCATENIN_IP_REP2,BLA203A25_S16_L002_R1_001.fastq.gz,
+WT_BCATENIN_IP_REP2,BLA203A25_S16_L003_R1_001.fastq.gz,
+WT_BCATENIN_IP_REP3,BLA203A49_S40_L001_R1_001.fastq.gz,
+WT_INPUT_REP1,BLA203A6_S32_L006_R1_001.fastq.gz,
+WT_INPUT_REP2,BLA203A30_S21_L001_R1_001.fastq.gz,
+WT_INPUT_REP2,BLA203A30_S21_L002_R1_001.fastq.gz,
+WT_INPUT_REP3,BLA203A31_S21_L003_R1_001.fastq.gz,
+```
+
 ### Full samplesheet
 
 The pipeline will auto-detect whether a sample is single- or paired-end using the information provided in the samplesheet. The samplesheet can have as many columns as you desire, however, there is a strict requirement for the first 3 columns to match those defined in the table below.
@@ -47,6 +64,15 @@ TREATMENT_REP3,AEG588A6_S6_L004_R1_001.fastq.gz,
 | `fastq_2` | Full path to FastQ file for Illumina short reads 2. File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
+
+## Reference genome files
+
+The minimum reference genome requirements are a FASTA and GTF file, all other files required to run the pipeline can be generated from these files. However, it is more storage and compute friendly if you are able to re-use reference genome files as efficiently as possible. It is recommended to use the `--save_reference` parameter if you are using the pipeline to build new indices (e.g. those unavailable on [AWS iGenomes](https://nf-co.re/usage/reference_genomes)) so that you can save them somewhere locally. The index building step can be quite a time-consuming process and it permits their reuse for future runs of the pipeline to save disk space. You can then either provide the appropriate reference genome files on the command-line via the appropriate parameters (e.g. `--bwa_index '/path/to/bwa/index/'`) or via a custom config file.
+
+- If `--genome` is provided then the FASTA and GTF files (and existing indices) will be automatically obtained from AWS-iGenomes unless these have already been downloaded locally in the path specified by `--igenomes_base`.
+- If `--gene_bed` is not provided then it will be generated from the GTF file.
+
+> **NB:** Compressed reference files are also supported by the pipeline i.e. standard files with the `.gz` extension and indices folders with the `tar.gz` extension.
 
 ## Blacklist bed files
 

--- a/lib/WorkflowAtacseq.groovy
+++ b/lib/WorkflowAtacseq.groovy
@@ -35,8 +35,12 @@ class WorkflowAtacseq {
             log.error "Both '--read_length' and '--macs_gsize' not specified! Please specify either to infer MACS2 genome size for peak calling."
             System.exit(1)
         }
-
-
+        if (params.aligner) {
+            if (!valid_params['aligners'].contains(params.aligner)) {
+                    log.error "Invalid option: '${params.aligner}'. Valid options for '--aligner': ${valid_params['aligners'].join(', ')}."
+                    System.exit(1)
+            }
+        }
     }
 
     //

--- a/lib/WorkflowAtacseq.groovy
+++ b/lib/WorkflowAtacseq.groovy
@@ -9,7 +9,7 @@ class WorkflowAtacseq {
     //
     // Check and validate parameters
     //
-    public static void initialise(params, log) {
+    public static void initialise(params, log, valid_params) {
         genomeExistsError(params, log)
 
 

--- a/main.nf
+++ b/main.nf
@@ -17,14 +17,17 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-params.fasta      = WorkflowMain.getGenomeAttribute(params, 'fasta')
-params.bwa_index  = WorkflowMain.getGenomeAttribute(params, 'bwa')
-params.gtf        = WorkflowMain.getGenomeAttribute(params, 'gtf')
-params.gff        = WorkflowMain.getGenomeAttribute(params, 'gff')
-params.gene_bed   = WorkflowMain.getGenomeAttribute(params, 'gene_bed')
-params.blacklist  = WorkflowMain.getGenomeAttribute(params, 'blacklist')
-params.mito_name  = WorkflowMain.getGenomeAttribute(params, 'mito_name')
-params.macs_gsize = WorkflowMain.getMacsGsize(params)
+params.fasta         = WorkflowMain.getGenomeAttribute(params, 'fasta')
+params.bwa_index     = WorkflowMain.getGenomeAttribute(params, 'bwa')
+params.bowtie2_index = WorkflowMain.getGenomeAttribute(params, 'bowtie2')
+params.chromap_index = WorkflowMain.getGenomeAttribute(params, 'chromap')
+params.star_index    = WorkflowMain.getGenomeAttribute(params, 'star')
+params.gtf           = WorkflowMain.getGenomeAttribute(params, 'gtf')
+params.gff           = WorkflowMain.getGenomeAttribute(params, 'gff')
+params.gene_bed      = WorkflowMain.getGenomeAttribute(params, 'gene_bed')
+params.blacklist     = WorkflowMain.getGenomeAttribute(params, 'blacklist')
+params.mito_name     = WorkflowMain.getGenomeAttribute(params, 'mito_name')
+params.macs_gsize    = WorkflowMain.getMacsGsize(params)
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules.json
+++ b/modules.json
@@ -13,11 +13,27 @@
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
                     },
+                    "bowtie2/align": {
+                        "branch": "master",
+                        "git_sha": "e797efb47b0d3b2124753beb55dc83ab9512bceb"
+                    },
+                    "bowtie2/build": {
+                        "branch": "master",
+                        "git_sha": "e797efb47b0d3b2124753beb55dc83ab9512bceb"
+                    },
                     "bwa/index": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
                     },
                     "bwa/mem": {
+                        "branch": "master",
+                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                    },
+                    "chromap/chromap": {
+                        "branch": "master",
+                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                    },
+                    "chromap/index": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
                     },

--- a/modules/local/igv.nf
+++ b/modules/local/igv.nf
@@ -47,5 +47,3 @@ process IGV {
     END_VERSIONS
     """
 }
-// find * -type f -name "*.FDR0.05.results.bed" -exec echo -e "bwa/mergedLibrary/macs/${PEAK_TYPE}/consensus/${antibody}/deseq2/"{}"\\t255,0,0" \\; > ${prefix}.igv.txt
-// find * -type f -name "*.FDR0.05.results.bed" -exec echo -e "bwa/mergedReplicate/macs/${PEAK_TYPE}/consensus/deseq2/"{}"\\t255,0,0" \\; > ${prefix}.igv.txt

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -1,0 +1,57 @@
+process STAR_ALIGN {
+    tag "$meta.id"
+    label 'process_high'
+
+    // Note: 2.7X indices incompatible with AWS iGenomes.
+    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/star:2.6.1d--0' :
+        'quay.io/biocontainers/star:2.6.1d--0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path  index
+
+    output:
+    tuple val(meta), path('*d.out.bam')       , emit: bam
+    tuple val(meta), path('*Log.final.out')   , emit: log_final
+    tuple val(meta), path('*Log.out')         , emit: log_out
+    tuple val(meta), path('*Log.progress.out'), emit: log_progress
+    path "versions.yml"                       , emit: versions
+
+    tuple val(meta), path('*sortedByCoord.out.bam')  , optional:true, emit: bam_sorted
+    tuple val(meta), path('*toTranscriptome.out.bam'), optional:true, emit: bam_transcript
+    tuple val(meta), path('*Aligned.unsort.out.bam') , optional:true, emit: bam_unsorted
+    tuple val(meta), path('*fastq.gz')               , optional:true, emit: fastq
+    tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def seq_center = params.seq_center ? "--outSAMattrRGline ID:$prefix 'CN:$params.seq_center' 'SM:$prefix'" : "--outSAMattrRGline ID:$prefix 'SM:$prefix'"
+    def out_sam_type = (args.contains('--outSAMtype')) ? '' : '--outSAMtype BAM Unsorted'
+    def mv_unsorted_bam = (args.contains('--outSAMtype BAM Unsorted SortedByCoordinate')) ? "mv ${prefix}.Aligned.out.bam ${prefix}.Aligned.unsort.out.bam" : ''
+    """
+    STAR \\
+        --genomeDir $index \\
+        --readFilesIn $reads  \\
+        --runThreadN $task.cpus \\
+        --outFileNamePrefix $prefix. \\
+        $out_sam_type \\
+        $seq_center \\
+        $args
+    $mv_unsorted_bam
+    if [ -f ${prefix}.Unmapped.out.mate1 ]; then
+        mv ${prefix}.Unmapped.out.mate1 ${prefix}.unmapped_1.fastq
+        gzip ${prefix}.unmapped_1.fastq
+    fi
+    if [ -f ${prefix}.Unmapped.out.mate2 ]; then
+        mv ${prefix}.Unmapped.out.mate2 ${prefix}.unmapped_2.fastq
+        gzip ${prefix}.unmapped_2.fastq
+    fi
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        star: \$(STAR --version | sed -e "s/STAR_//g")
+    END_VERSIONS
+    """
+}

--- a/modules/local/star_genomegenerate.nf
+++ b/modules/local/star_genomegenerate.nf
@@ -1,0 +1,58 @@
+process STAR_GENOMEGENERATE {
+    tag "$fasta"
+    label 'process_high'
+
+    // Note: 2.7X indices incompatible with AWS iGenomes.
+    conda (params.enable_conda ? "bioconda::star=2.6.1d bioconda::samtools=1.10 conda-forge::gawk=5.1.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0' :
+        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0' }"
+
+    input:
+    path fasta
+    path gtf
+
+    output:
+    path "star"        , emit: index
+    path "versions.yml", emit: versions
+
+    script:
+    def args   = (task.ext.args ?: '').tokenize()
+    def memory = task.memory ? "--limitGenomeGenerateRAM ${task.memory.toBytes() - 100000000}" : ''
+    if (args.contains('--genomeSAindexNbases')) {
+        """
+        mkdir star
+        STAR \\
+            --runMode genomeGenerate \\
+            --genomeDir star/ \\
+            --genomeFastaFiles $fasta \\
+            --sjdbGTFfile $gtf \\
+            --runThreadN $task.cpus \\
+            $memory \\
+            ${args.join(' ')}
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            star: \$(STAR --version | sed -e "s/STAR_//g")
+        END_VERSIONS
+        """
+    } else {
+        """
+        samtools faidx $fasta
+        NUM_BASES=`gawk '{sum = sum + \$2}END{if ((log(sum)/log(2))/2 - 1 > 14) {printf "%.0f", 14} else {printf "%.0f", (log(sum)/log(2))/2 - 1}}' ${fasta}.fai`
+        mkdir star
+        STAR \\
+            --runMode genomeGenerate \\
+            --genomeDir star/ \\
+            --genomeFastaFiles $fasta \\
+            --sjdbGTFfile $gtf \\
+            --runThreadN $task.cpus \\
+            --genomeSAindexNbases \$NUM_BASES \\
+            $memory \\
+            ${args.join(' ')}
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            star: \$(STAR --version | sed -e "s/STAR_//g")
+        END_VERSIONS
+        """
+    }
+}

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -1,0 +1,71 @@
+process BOWTIE2_ALIGN {
+    tag "$meta.id"
+    label "process_high"
+
+    conda (params.enable_conda ? "bioconda::bowtie2=2.4.4 bioconda::samtools=1.15.1 conda-forge::pigz=2.6" : null)
+    container "${ workflow.containerEngine == "singularity" && !task.ext.singularity_pull_docker_container ?
+        "https://depot.galaxyproject.org/singularity/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:1744f68fe955578c63054b55309e05b41c37a80d-0" :
+        "quay.io/biocontainers/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:1744f68fe955578c63054b55309e05b41c37a80d-0" }"
+
+    input:
+    tuple val(meta) , path(reads)
+    tuple val(meta2), path(index)
+    val   save_unaligned
+    val   sort_bam
+
+    output:
+    tuple val(meta), path("*.bam")    , emit: bam
+    tuple val(meta), path("*.log")    , emit: log
+    tuple val(meta), path("*fastq.gz"), emit: fastq, optional:true
+    path  "versions.yml"              , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+    def args2 = task.ext.args2 ?: ""
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    def unaligned = ""
+    def reads_args = ""
+    if (meta.single_end) {
+        unaligned = save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ""
+        reads_args = "-U ${reads}"
+    } else {
+        unaligned = save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ""
+        reads_args = "-1 ${reads[0]} -2 ${reads[1]}"
+    }
+
+    def samtools_command = sort_bam ? 'sort' : 'view'
+
+    """
+    INDEX=`find -L ./ -name "*.rev.1.bt2" | sed "s/.rev.1.bt2//"`
+    [ -z "\$INDEX" ] && INDEX=`find -L ./ -name "*.rev.1.bt2l" | sed "s/.rev.1.bt2l//"`
+    [ -z "\$INDEX" ] && echo "Bowtie2 index files not found" 1>&2 && exit 1
+
+    bowtie2 \\
+        -x \$INDEX \\
+        $reads_args \\
+        --threads $task.cpus \\
+        $unaligned \\
+        $args \\
+        2> ${prefix}.bowtie2.log \\
+        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam -
+
+    if [ -f ${prefix}.unmapped.fastq.1.gz ]; then
+        mv ${prefix}.unmapped.fastq.1.gz ${prefix}.unmapped_1.fastq.gz
+    fi
+
+    if [ -f ${prefix}.unmapped.fastq.2.gz ]; then
+        mv ${prefix}.unmapped.fastq.2.gz ${prefix}.unmapped_2.fastq.gz
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bowtie2/align/meta.yml
+++ b/modules/nf-core/bowtie2/align/meta.yml
@@ -1,0 +1,67 @@
+name: bowtie2_align
+description: Align reads to a reference genome using bowtie2
+keywords:
+  - align
+  - map
+  - fasta
+  - fastq
+  - genome
+  - reference
+tools:
+  - bowtie2:
+      description: |
+        Bowtie 2 is an ultrafast and memory-efficient tool for aligning
+        sequencing reads to long reference sequences.
+      homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+      documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+      doi: 10.1038/nmeth.1923
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - index:
+      type: file
+      description: Bowtie2 genome index files
+      pattern: "*.ebwt"
+  - save_unaligned:
+      type: boolean
+      description: |
+        Save reads that do not map to the reference (true) or discard them (false)
+        (default: false)
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
+output:
+  - bam:
+      type: file
+      description: Output BAM file containing read alignments
+      pattern: "*.{bam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - fastq:
+      type: file
+      description: Unaligned FastQ files
+      pattern: "*.fastq.gz"
+  - log:
+      type: file
+      description: Aligment log
+      pattern: "*.log"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/bowtie2/build/main.nf
+++ b/modules/nf-core/bowtie2/build/main.nf
@@ -1,0 +1,30 @@
+process BOWTIE2_BUILD {
+    tag "$fasta"
+    label 'process_high'
+
+    conda (params.enable_conda ? 'bioconda::bowtie2=2.4.4' : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bowtie2:2.4.4--py39hbb4e92a_0' :
+        'quay.io/biocontainers/bowtie2:2.4.4--py39hbb4e92a_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path('bowtie2')    , emit: index
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    mkdir bowtie2
+    bowtie2-build $args --threads $task.cpus $fasta bowtie2/${fasta.baseName}
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bowtie2/build/meta.yml
+++ b/modules/nf-core/bowtie2/build/meta.yml
@@ -1,0 +1,43 @@
+name: bowtie2_build
+description: Builds bowtie index for reference genome
+keywords:
+  - build
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - bowtie2:
+      description: |
+        Bowtie 2 is an ultrafast and memory-efficient tool for aligning
+        sequencing reads to long reference sequences.
+      homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+      documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+      doi: 10.1038/nmeth.1923
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Input genome fasta file
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - index:
+      type: file
+      description: Bowtie2 genome index files
+      pattern: "*.bt2"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -1,0 +1,95 @@
+process CHROMAP_CHROMAP {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda (params.enable_conda ? "bioconda::chromap=0.2.1 bioconda::samtools=1.15.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:963e4fe6a85c548a4018585660aed79780a175d3-0' :
+        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:963e4fe6a85c548a4018585660aed79780a175d3-0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path fasta
+    path index
+    path barcodes
+    path whitelist
+    path chr_order
+    path pairs_chr_order
+
+    output:
+    tuple val(meta), path("*.bed.gz")     , optional:true, emit: bed
+    tuple val(meta), path("*.bam")        , optional:true, emit: bam
+    tuple val(meta), path("*.tagAlign.gz"), optional:true, emit: tagAlign
+    tuple val(meta), path("*.pairs.gz")   , optional:true, emit: pairs
+    path "versions.yml"                                  , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args_list = args.tokenize()
+
+    def file_extension = args.contains("--SAM") ? 'sam' : args.contains("--TagAlign")? 'tagAlign' : args.contains("--pairs")? 'pairs' : 'bed'
+    if (barcodes) {
+        args_list << "-b ${barcodes.join(',')}"
+        if (whitelist) {
+            args_list << "--barcode-whitelist $whitelist"
+        }
+    }
+    if (chr_order) {
+        args_list << "--chr-order $chr_order"
+    }
+    if (pairs_chr_order){
+        args_list << "--pairs-natural-chr-order $pairs_chr_order"
+    }
+    def final_args = args_list.join(' ')
+    def compression_cmds = "gzip -n ${prefix}.${file_extension}"
+    if (args.contains("--SAM")) {
+        compression_cmds = """
+        samtools view $args2 -@ $task.cpus -bh \\
+            -o ${prefix}.bam ${prefix}.${file_extension}
+        rm ${prefix}.${file_extension}
+        """
+    }
+    if (meta.single_end) {
+        """
+        chromap \\
+            $final_args \\
+            -t $task.cpus \\
+            -x $index \\
+            -r $fasta \\
+            -1 ${reads.join(',')} \\
+            -o ${prefix}.${file_extension}
+
+        $compression_cmds
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            chromap: \$(echo \$(chromap --version 2>&1))
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        chromap \\
+            $final_args \\
+            -t $task.cpus \\
+            -x $index \\
+            -r $fasta \\
+            -1 ${reads[0]} \\
+            -2 ${reads[1]} \\
+            -o ${prefix}.${file_extension}
+
+        $compression_cmds
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            chromap: \$(echo \$(chromap --version 2>&1))
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        END_VERSIONS
+        """
+    }
+}

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -1,0 +1,88 @@
+name: chromap_chromap
+description: |
+  Performs preprocessing and alignment of chromatin fastq files to
+  fasta reference files using chromap.
+keywords:
+  - chromap
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+  - hi-c
+  - atac-seq
+  - chip-seq
+  - trimming
+  - duplicate removal
+tools:
+  - chromap:
+      description: Fast alignment and preprocessing of chromatin profiles
+      homepage: https://github.com/haowenz/chromap
+      documentation: https://github.com/haowenz/chromap
+      tool_dev_url: https://github.com/haowenz/chromap
+      doi: ""
+      licence: ["GPL v3"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - fasta:
+      type: file
+      description: |
+        The fasta reference file.
+  - index:
+      type: file
+      description: |
+        Chromap genome index files (*.index)
+  - barcodes:
+      type: file
+      description: |
+        Cell barcode files
+  - whitelist:
+      type: file
+      description: |
+        Cell barcode whitelist file
+  - chr_order:
+      type: file
+      description: |
+        Custom chromosome order
+  - pairs_chr_order:
+      type: file
+      description: |
+        Natural chromosome order for pairs flipping
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - bed:
+      type: file
+      description: BED file
+      pattern: "*.bed.gz"
+  - bam:
+      type: file
+      description: BAM file
+      pattern: "*.bam"
+  - tagAlign:
+      type: file
+      description: tagAlign file
+      pattern: "*.tagAlign.gz"
+  - pairs:
+      type: file
+      description: pairs file
+      pattern: "*.pairs.gz"
+
+authors:
+  - "@mahesh-panchal"

--- a/modules/nf-core/chromap/index/main.nf
+++ b/modules/nf-core/chromap/index/main.nf
@@ -1,0 +1,36 @@
+process CHROMAP_INDEX {
+    tag "$fasta"
+    label 'process_medium'
+
+    conda (params.enable_conda ? "bioconda::chromap=0.2.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/chromap:0.2.1--hd03093a_0' :
+        'quay.io/biocontainers/chromap:0.2.1--hd03093a_0' }"
+
+    input:
+    path fasta
+
+    output:
+    path "*.index"     , emit: index
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = fasta.baseName
+    """
+    chromap \\
+        -i \\
+        $args \\
+        -t $task.cpus \\
+        -r $fasta \\
+        -o ${prefix}.index
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        chromap: \$(echo \$(chromap --version 2>&1))
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/chromap/index/meta.yml
+++ b/modules/nf-core/chromap/index/meta.yml
@@ -1,0 +1,33 @@
+name: chromap_index
+description: Indexes a fasta reference genome ready for chromatin profiling.
+keywords:
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - chromap:
+      description: Fast alignment and preprocessing of chromatin profiles
+      homepage: https://github.com/haowenz/chromap
+      documentation: https://github.com/haowenz/chromap
+      tool_dev_url: https://github.com/haowenz/chromap
+      doi: ""
+      licence: ["GPL v3"]
+
+input:
+  - fasta:
+      type: file
+      description: Fasta reference file.
+
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - index:
+      type: file
+      description: Index file of the reference genome
+      pattern: "*.{index}"
+
+authors:
+  - "@mahesh-panchal"

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,7 @@ params {
     keep_multi_map             = false
     skip_merge_replicates      = false
     save_align_intermeds       = false
+    save_unaligned             = false
 
     // Options: Peaks
     narrow_peak                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -236,7 +236,7 @@
                 "aligner": {
                     "type": "string",
                     "default": "bwa",
-                    "description": "Specifies the alignment algorithm to use - available options is 'bwa'.",
+                    "description": "Specifies the alignment algorithm to use - available options are 'bwa', 'bowtie2' and 'star'.",
                     "fa_icon": "fas fa-map-signs",
                     "enum": ["bwa", "bowtie2", "chromap", "star"]
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -220,7 +220,7 @@
                     "default": "bwa",
                     "description": "Specifies the alignment algorithm to use - available options is 'bwa'.",
                     "fa_icon": "fas fa-map-signs",
-                    "enum": ["bwa"]
+                    "enum": ["bwa", "bowtie2", "chromap", "star"]
                 },
                 "keep_dups": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -103,6 +103,24 @@
                     "description": "Path to directory or tar.gz archive for pre-built BWA index.",
                     "fa_icon": "fas fa-bezier-curve"
                 },
+                "bowtie2_index": {
+                    "type": "string",
+                    "format": "path",
+                    "fa_icon": "fas fa-bezier-curve",
+                    "description": "Path to directory or tar.gz archive for pre-built Bowtie2 index."
+                },
+                "chromap_index": {
+                    "type": "string",
+                    "format": "path",
+                    "fa_icon": "fas fa-bezier-curve",
+                    "description": "Path to directory or tar.gz archive for pre-built Chromap index."
+                },
+                "star_index": {
+                    "type": "string",
+                    "format": "path",
+                    "fa_icon": "fas fa-bezier-curve",
+                    "description": "Path to directory or tar.gz archive for pre-built STAR index."
+                },
                 "gene_bed": {
                     "type": "string",
                     "format": "file-path",
@@ -249,6 +267,12 @@
                     "description": "Save the intermediate BAM files from the alignment step.",
                     "help_text": "By default, intermediate BAM files will not be saved. The final BAM files created after the appropriate filtering step are always saved to limit storage usage. Set this parameter to also save other intermediate BAM files.",
                     "fa_icon": "fas fa-save"
+                },
+                "save_unaligned": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-save",
+                    "description": "Where possible, save unaligned reads from either STAR, HISAT2 or Salmon to the results directory.",
+                    "help_text": "This may either be in the form of FastQ or BAM files depending on the options available for that particular tool."
                 },
                 "bamtools_filter_pe_config": {
                     "type": "string",

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -155,16 +155,19 @@ workflow PREPARE_GENOME {
     //
     ch_bwa_index = Channel.empty()
     if (prepare_tool_index == 'bwa') {
-        if (params.bwa_index.endsWith('.tar.gz')) {
-            ch_bwa_index = UNTAR ( [ [:], params.bwa_index ] ).untar.map{ it[1] }
-            ch_versions  = ch_versions.mix(UNTAR.out.versions)
+        if (params.bwa_index) {
+            if (params.bwa_index.endsWith('.tar.gz')) {
+                ch_bwa_index = UNTAR_BWA_INDEX ( [ [:], params.bwa_index ] ).untar.map{ it[1] }
+                ch_versions  = ch_versions.mix(UNTAR_BWA_INDEX.out.versions)
+            } else {
+                ch_bwa_index = file(params.bwa_index)
+            }
         } else {
-            ch_bwa_index = file(params.bwa_index)
+            ch_bwa_index = BWA_INDEX ( ch_fasta ).index
+            ch_versions  = ch_versions.mix(BWA_INDEX.out.versions)
         }
-    } else {
-        ch_bwa_index = BWA_INDEX ( ch_fasta ).index
-        ch_versions  = ch_versions.mix(BWA_INDEX.out.versions)
     }
+
     //
     // Uncompress Bowtie2 index or generate from scratch if required
     //

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -154,7 +154,7 @@ workflow PREPARE_GENOME {
     // Uncompress BWA index or generate from scratch if required
     //
     ch_bwa_index = Channel.empty()
-    if (params.bwa_index) {
+    if (prepare_tool_index == 'bwa') {
         if (params.bwa_index.endsWith('.tar.gz')) {
             ch_bwa_index = UNTAR ( [ [:], params.bwa_index ] ).untar.map{ it[1] }
             ch_versions  = ch_versions.mix(UNTAR.out.versions)

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -29,8 +29,10 @@ include { GET_AUTOSOMES            } from '../../modules/local/get_autosomes'
 include { TSS_EXTRACT              } from '../../modules/local/tss_extract'
 
 workflow PREPARE_GENOME {
-    main:
+    take:
+    prepare_tool_index // string  : tool to prepare index for
 
+    main:
     ch_versions = Channel.empty()
 
     //

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -10,10 +10,18 @@ include {
     GUNZIP as GUNZIP_TSS_BED
     GUNZIP as GUNZIP_BLACKLIST } from '../../modules/nf-core/gunzip/main'
 
-include { UNTAR                } from '../../modules/nf-core/untar/main'
+include {
+    UNTAR as UNTAR_BWA_INDEX
+    UNTAR as UNTAR_BOWTIE2_INDEX
+    UNTAR as UNTAR_CHROMAP_INDEX
+    UNTAR as UNTAR_STAR_INDEX    } from '../../modules/nf-core/modules/untar/main'
+
 include { GFFREAD              } from '../../modules/nf-core/gffread/main'
 include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
 include { BWA_INDEX            } from '../../modules/nf-core/bwa/index/main'
+include { BOWTIE2_BUILD        } from '../../modules/nf-core/modules/bowtie2/build/main'
+include { CHROMAP_INDEX        } from '../../modules/nf-core/modules/chromap/index/main'
+include { STAR_GENOMEGENERATE  } from '../../modules/local/star_genomegenerate'
 
 include { GTF2BED                  } from '../../modules/local/gtf2bed'
 include { GENOME_BLACKLIST_REGIONS } from '../../modules/local/genome_blacklist_regions'
@@ -155,17 +163,73 @@ workflow PREPARE_GENOME {
         ch_bwa_index = BWA_INDEX ( ch_fasta ).index
         ch_versions  = ch_versions.mix(BWA_INDEX.out.versions)
     }
+    //
+    // Uncompress Bowtie2 index or generate from scratch if required
+    //
+    ch_bowtie2_index = Channel.empty()
+    if (prepare_tool_index == 'bowtie2') {
+        if (params.bowtie2_index) {
+            if (params.bowtie2_index.endsWith('.tar.gz')) {
+                ch_bowtie2_index = UNTAR_BOWTIE2_INDEX ( [ [:], params.bowtie2_index ] ).untar.map{ it[1] }
+                ch_versions  = ch_versions.mix(UNTAR_BOWTIE2_INDEX.out.versions)
+            } else {
+                ch_bowtie2_index = file(params.bowtie2_index)
+            }
+        } else {
+            ch_bowtie2_index = BOWTIE2_BUILD ( ch_fasta ).index
+            ch_versions      = ch_versions.mix(BOWTIE2_BUILD.out.versions)
+        }
+    }
+
+    //
+    // Uncompress CHROMAP index or generate from scratch if required
+    //
+    ch_chromap_index = Channel.empty()
+    if (prepare_tool_index == 'chromap') {
+        if (params.chromap_index) {
+            if (params.chromap_index.endsWith('.tar.gz')) {
+                ch_chromap_index = UNTAR_CHROMAP_INDEX ( [ [:], params.chromap_index ] ).untar.map{ it[1] }
+                ch_versions  = ch_versions.mix(UNTAR.out.versions)
+            } else {
+                ch_chromap_index = file(params.chromap_index)
+            }
+        } else {
+            ch_chromap_index = CHROMAP_INDEX ( ch_fasta ).index
+            ch_versions  = ch_versions.mix(CHROMAP_INDEX.out.versions)
+        }
+    }
+
+    //
+    // Uncompress STAR index or generate from scratch if required
+    //
+    ch_star_index = Channel.empty()
+    if (prepare_tool_index == 'star') {
+        if (params.star_index) {
+            if (params.star_index.endsWith('.tar.gz')) {
+                ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar.map{ it[1] }
+                ch_versions   = ch_versions.mix(UNTAR_STAR_INDEX.out.versions)
+            } else {
+                ch_star_index = file(params.star_index)
+            }
+        } else {
+            ch_star_index = STAR_GENOMEGENERATE ( ch_fasta, ch_gtf ).index
+            ch_versions   = ch_versions.mix(STAR_GENOMEGENERATE.out.versions)
+        }
+    }
 
     emit:
     fasta         = ch_fasta                      //    path: genome.fasta
-    fai           = ch_fai  //    path: genome.fai
+    fai           = ch_fai                        //    path: genome.fai
     gtf           = ch_gtf                        //    path: genome.gtf
     gene_bed      = ch_gene_bed                   //    path: gene.bed
     tss_bed       = ch_tss_bed                    //    path: tss.bed
     chrom_sizes   = ch_chrom_sizes                //    path: genome.sizes
     filtered_bed  = ch_genome_filtered_bed        //    path: *.include_regions.bed
     bwa_index     = ch_bwa_index                  //    path: bwa/index/
+    bowtie2_index = ch_bowtie2_index              //    path: bowtie2/index/
+    chromap_index = ch_chromap_index              //    path: genome.index
+    star_index    = ch_star_index                 //    path: star/index/
     autosomes     = ch_genome_autosomes           //    path: *.autosomes.txt
 
-    versions    = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+    versions    = ch_versions.ifEmpty(null)       // channel: [ versions.yml ]
 }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -14,13 +14,13 @@ include {
     UNTAR as UNTAR_BWA_INDEX
     UNTAR as UNTAR_BOWTIE2_INDEX
     UNTAR as UNTAR_CHROMAP_INDEX
-    UNTAR as UNTAR_STAR_INDEX    } from '../../modules/nf-core/modules/untar/main'
+    UNTAR as UNTAR_STAR_INDEX    } from '../../modules/nf-core/untar/main'
 
 include { GFFREAD              } from '../../modules/nf-core/gffread/main'
 include { CUSTOM_GETCHROMSIZES } from '../../modules/nf-core/custom/getchromsizes/main'
 include { BWA_INDEX            } from '../../modules/nf-core/bwa/index/main'
-include { BOWTIE2_BUILD        } from '../../modules/nf-core/modules/bowtie2/build/main'
-include { CHROMAP_INDEX        } from '../../modules/nf-core/modules/chromap/index/main'
+include { BOWTIE2_BUILD        } from '../../modules/nf-core/bowtie2/build/main'
+include { CHROMAP_INDEX        } from '../../modules/nf-core/chromap/index/main'
 include { STAR_GENOMEGENERATE  } from '../../modules/local/star_genomegenerate'
 
 include { GTF2BED                  } from '../../modules/local/gtf2bed'

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -181,7 +181,7 @@ workflow PREPARE_GENOME {
                 ch_bowtie2_index = file(params.bowtie2_index)
             }
         } else {
-            ch_bowtie2_index = BOWTIE2_BUILD ( ch_fasta ).index
+            ch_bowtie2_index = BOWTIE2_BUILD ( [ [:], ch_fasta ] ).index
             ch_versions      = ch_versions.mix(BOWTIE2_BUILD.out.versions)
         }
     }

--- a/subworkflows/nf-core/align_bowtie2.nf
+++ b/subworkflows/nf-core/align_bowtie2.nf
@@ -1,0 +1,38 @@
+/*
+ * Map reads, sort, index BAM file and run samtools stats, flagstat and idxstats
+ */
+
+include { BOWTIE2_ALIGN     } from '../../modules/nf-core/bowtie2/align/main'
+include { BAM_SORT_SAMTOOLS } from './bam_sort_samtools'
+
+workflow ALIGN_BOWTIE2 {
+    take:
+    reads          // channel: [ val(meta), [ reads ] ]
+    index          //    path: /path/to/index
+    save_unaligned // boolean: true/false
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    //
+    // Map reads with BWA
+    //
+    BOWTIE2_ALIGN(reads, index, save_unaligned, false)
+    ch_versions = ch_versions.mix(BOWTIE2_ALIGN.out.versions.first())
+
+    //
+    // Sort, index BAM file and run samtools stats, flagstat and idxstats
+    //
+    BAM_SORT_SAMTOOLS(BOWTIE2_ALIGN.out.bam)
+    ch_versions = ch_versions.mix(BAM_SORT_SAMTOOLS.out.versions.first())
+
+    emit:
+    bam               = BAM_SORT_SAMTOOLS.out.bam               // channel: [ val(meta), [ bam ] ]
+    bai               = BAM_SORT_SAMTOOLS.out.bai               // channel: [ val(meta), [ bai ] ]
+    stats             = BAM_SORT_SAMTOOLS.out.stats             // channel: [ val(meta), [ stats ] ]
+    flagstat          = BAM_SORT_SAMTOOLS.out.flagstat          // channel: [ val(meta), [ flagstat ] ]
+    idxstats          = BAM_SORT_SAMTOOLS.out.idxstats          // channel: [ val(meta), [ idxstats ] ]
+
+    versions          = ch_versions                             //    path: versions.yml
+}

--- a/subworkflows/nf-core/align_chromap.nf
+++ b/subworkflows/nf-core/align_chromap.nf
@@ -1,0 +1,38 @@
+/*
+ * Map reads, sort, index BAM file and run samtools stats, flagstat and idxstats
+ */
+
+include { CHROMAP_CHROMAP   } from '../../modules/nf-core/chromap/chromap/main'
+include { BAM_SORT_SAMTOOLS } from './bam_sort_samtools'
+
+workflow ALIGN_CHROMAP {
+    take:
+    reads // channel: [ val(meta), [ reads ] ]
+    index //    path: /path/to/index
+    fasta //    path: /path/to/fasta
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    //
+    // Map reads with CHROMAP
+    //
+    CHROMAP_CHROMAP(reads, fasta, index, [], [], [], [])
+    ch_versions = ch_versions.mix(CHROMAP_CHROMAP.out.versions.first())
+
+    //
+    // Sort, index BAM file and run samtools stats, flagstat and idxstats
+    //
+    BAM_SORT_SAMTOOLS(CHROMAP_CHROMAP.out.bam)
+    ch_versions = ch_versions.mix(BAM_SORT_SAMTOOLS.out.versions.first())
+
+    emit:
+    bam               = BAM_SORT_SAMTOOLS.out.bam               // channel: [ val(meta), [ bam ] ]
+    bai               = BAM_SORT_SAMTOOLS.out.bai               // channel: [ val(meta), [ bai ] ]
+    stats             = BAM_SORT_SAMTOOLS.out.stats             // channel: [ val(meta), [ stats ] ]
+    flagstat          = BAM_SORT_SAMTOOLS.out.flagstat          // channel: [ val(meta), [ flagstat ] ]
+    idxstats          = BAM_SORT_SAMTOOLS.out.idxstats          // channel: [ val(meta), [ idxstats ] ]
+
+    versions          = ch_versions                             //    path: versions.yml
+}

--- a/subworkflows/nf-core/align_star.nf
+++ b/subworkflows/nf-core/align_star.nf
@@ -1,0 +1,46 @@
+/*
+ * Map reads, sort, index BAM file and run samtools stats, flagstat and idxstats
+ */
+
+include { STAR_ALIGN        } from '../../modules/local/star_align'
+include { BAM_SORT_SAMTOOLS } from './bam_sort_samtools'
+
+workflow ALIGN_STAR {
+    take:
+    reads // channel: [ val(meta), [ reads ] ]
+    index // channel: /path/to/star/index/
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    //
+    // Map reads with STAR
+    //
+    STAR_ALIGN ( reads, index )
+    ch_versions = ch_versions.mix(STAR_ALIGN.out.versions.first())
+
+    //
+    // Sort, index BAM file and run samtools stats, flagstat and idxstats
+    //
+    BAM_SORT_SAMTOOLS ( STAR_ALIGN.out.bam )
+    ch_versions = ch_versions.mix(BAM_SORT_SAMTOOLS.out.versions)
+
+    emit:
+    orig_bam       = STAR_ALIGN.out.bam             // channel: [ val(meta), bam            ]
+    log_final      = STAR_ALIGN.out.log_final       // channel: [ val(meta), log_final      ]
+    log_out        = STAR_ALIGN.out.log_out         // channel: [ val(meta), log_out        ]
+    log_progress   = STAR_ALIGN.out.log_progress    // channel: [ val(meta), log_progress   ]
+    bam_sorted     = STAR_ALIGN.out.bam_sorted      // channel: [ val(meta), bam_sorted     ]
+    bam_transcript = STAR_ALIGN.out.bam_transcript  // channel: [ val(meta), bam_transcript ]
+    fastq          = STAR_ALIGN.out.fastq           // channel: [ val(meta), fastq          ]
+    tab            = STAR_ALIGN.out.tab             // channel: [ val(meta), tab            ]
+
+    bam            = BAM_SORT_SAMTOOLS.out.bam      // channel: [ val(meta), [ bam ] ]
+    bai            = BAM_SORT_SAMTOOLS.out.bai      // channel: [ val(meta), [ bai ] ]
+    stats          = BAM_SORT_SAMTOOLS.out.stats    // channel: [ val(meta), [ stats ] ]
+    flagstat       = BAM_SORT_SAMTOOLS.out.flagstat // channel: [ val(meta), [ flagstat ] ]
+    idxstats       = BAM_SORT_SAMTOOLS.out.idxstats // channel: [ val(meta), [ idxstats ] ]
+
+    versions       = ch_versions                    // channel: [ versions.yml ]
+}

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -4,17 +4,21 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
+def valid_params = [
+    aligners       : [ 'bwa', 'bowtie2', 'chromap', 'star' ]
+]
+
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 
 // Validate input parameters
-WorkflowAtacseq.initialise(params, log)
+WorkflowAtacseq.initialise(params, log, valid_params))
 
 // Check input path parameters to see if they exist
 def checkPathParamList = [
     params.input, params.multiqc_config,
     params.fasta,
     params.gtf, params.gff, params.gene_bed,
-    params.bwa_index,
+    params.bwa_index, params.bowtie2_index, params.chromap_index, params.star_index,
     params.blacklist,
     params.bamtools_filter_pe_config, params.bamtools_filter_se_config
 ]
@@ -148,7 +152,9 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Uncompress and prepare reference genome files
     //
-    PREPARE_GENOME ()
+    PREPARE_GENOME (
+        params.aligner
+    )
     ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 
     //
@@ -173,16 +179,107 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Alignment with BWA & BAM QC
     //
-    ALIGN_BWA_MEM (
-        FASTQC_TRIMGALORE.out.reads,
-        PREPARE_GENOME.out.bwa_index
-    )
-    ch_genome_bam        = ALIGN_BWA_MEM.out.bam
-    ch_genome_bam_index  = ALIGN_BWA_MEM.out.bai
-    ch_samtools_stats    = ALIGN_BWA_MEM.out.stats
-    ch_samtools_flagstat = ALIGN_BWA_MEM.out.flagstat
-    ch_samtools_idxstats = ALIGN_BWA_MEM.out.idxstats
-    ch_versions = ch_versions.mix(ALIGN_BWA_MEM.out.versions.first())
+    ch_genome_bam        = Channel.empty()
+    ch_genome_bam_index  = Channel.empty()
+    ch_samtools_stats    = Channel.empty()
+    ch_samtools_flagstat = Channel.empty()
+    ch_samtools_idxstats = Channel.empty()
+    if (params.aligner == 'bwa') {
+        ALIGN_BWA_MEM (
+            FASTQC_TRIMGALORE.out.reads,
+            PREPARE_GENOME.out.bwa_index
+        )
+        ch_genome_bam        = ALIGN_BWA_MEM.out.bam
+        ch_genome_bam_index  = ALIGN_BWA_MEM.out.bai
+        ch_samtools_stats    = ALIGN_BWA_MEM.out.stats
+        ch_samtools_flagstat = ALIGN_BWA_MEM.out.flagstat
+        ch_samtools_idxstats = ALIGN_BWA_MEM.out.idxstats
+        ch_versions = ch_versions.mix(ALIGN_BWA_MEM.out.versions.first())
+    }
+
+    //
+    // SUBWORKFLOW: Alignment with Bowtie2 & BAM QC
+    //
+    if (params.aligner == 'bowtie2') {
+        ALIGN_BOWTIE2 (
+            FASTQC_TRIMGALORE.out.reads,
+            PREPARE_GENOME.out.bowtie2_index,
+            params.save_unaligned
+        )
+        ch_genome_bam        = ALIGN_BOWTIE2.out.bam
+        ch_genome_bam_index  = ALIGN_BOWTIE2.out.bai
+        ch_samtools_stats    = ALIGN_BOWTIE2.out.stats
+        ch_samtools_flagstat = ALIGN_BOWTIE2.out.flagstat
+        ch_samtools_idxstats = ALIGN_BOWTIE2.out.idxstats
+        ch_versions = ch_versions.mix(ALIGN_BOWTIE2.out.versions.first())
+    }
+
+    //
+    // SUBWORKFLOW: Alignment with Chromap & BAM QC
+    //
+    if (params.aligner == 'chromap') {
+        ALIGN_CHROMAP (
+            FASTQC_TRIMGALORE.out.reads,
+            PREPARE_GENOME.out.chromap_index,
+            PREPARE_GENOME.out.fasta
+        )
+
+        // Filter out paired-end reads until the issue below is fixed
+        // https://github.com/nf-core/chipseq/issues/291
+        // ch_genome_bam = ALIGN_CHROMAP.out.bam
+        ALIGN_CHROMAP
+            .out
+            .bam
+            .branch {
+                meta, bam ->
+                    single_end: meta.single_end
+                        return [ meta, bam ]
+                    paired_end: !meta.single_end
+                        return [ meta, bam ]
+            }
+            .set { ch_genome_bam_chromap }
+
+        ch_genome_bam_chromap
+            .paired_end
+            .collect()
+            .map {
+                it ->
+                    def count = it.size()
+                    if (count > 0) {
+                        log.warn "=============================================================================\n" +
+                        "  Paired-end files produced by chromap cannot be used by some downstream tools due to the issue below:\n" +
+                        "  https://github.com/nf-core/chipseq/issues/291\n" +
+                        "  They will be excluded from the analysis. Consider using a different aligner\n" +
+                        "==================================================================================="
+                    }
+            }
+
+        ch_genome_bam        = ch_genome_bam_chromap.single_end
+        ch_genome_bam_index  = ALIGN_CHROMAP.out.bai
+        ch_samtools_stats    = ALIGN_CHROMAP.out.stats
+        ch_samtools_flagstat = ALIGN_CHROMAP.out.flagstat
+        ch_samtools_idxstats = ALIGN_CHROMAP.out.idxstats
+        ch_versions = ch_versions.mix(ALIGN_CHROMAP.out.versions.first())
+    }
+
+    //
+    // SUBWORKFLOW: Alignment with STAR & BAM QC
+    //
+    if (params.aligner == 'star') {
+        ALIGN_STAR (
+            FASTQC_TRIMGALORE.out.reads,
+            PREPARE_GENOME.out.star_index
+        )
+        ch_genome_bam        = ALIGN_STAR.out.bam
+        ch_genome_bam_index  = ALIGN_STAR.out.bai
+        ch_transcriptome_bam = ALIGN_STAR.out.bam_transcript
+        ch_samtools_stats    = ALIGN_STAR.out.stats
+        ch_samtools_flagstat = ALIGN_STAR.out.flagstat
+        ch_samtools_idxstats = ALIGN_STAR.out.idxstats
+        ch_star_multiqc      = ALIGN_STAR.out.log_final
+
+        ch_versions = ch_versions.mix(ALIGN_STAR.out.versions)
+    }
 
     //
     // MERGE LIBRARY BAM
@@ -773,18 +870,18 @@ workflow ATACSEQ {
             ch_ucsc_bedgraphtobigwig_rep_bigwig.collect{it[1]}.ifEmpty([]),
             ch_macs2_peaks_rep.collect{it[1]}.ifEmpty([]),
             ch_macs2_consensus_bed_rep.collect{it[1]}.ifEmpty([]),
-            "bwa/mergedLibrary/bigwig",
-            { ["bwa/mergedLibrary/macs2",
+            "${params.aligner}/mergedLibrary/bigwig",
+            { ["${params.aligner}/mergedLibrary/macs2",
                 params.narrow_peak? '/narrowPeak' : '/broadPeak'
                 ].join('') },
-            { ["bwa/mergedLibrary/macs2",
+            { ["${params.aligner}/mergedLibrary/macs2",
                 params.narrow_peak? '/narrowPeak' : '/broadPeak'
                 ].join('') },
-            "bwa/mergedReplicate/bigwig",
-            { ["bwa/mergedReplicate/macs2",
+            "${params.aligner}/mergedReplicate/bigwig",
+            { ["${params.aligner}/mergedReplicate/macs2",
                 params.narrow_peak? '/narrowPeak' : '/broadPeak'
                 ].join('') },
-            { ["bwa/mergedReplicate/macs2",
+            { ["${params.aligner}/mergedReplicate/macs2",
                 params.narrow_peak? '/narrowPeak' : '/broadPeak'
                 ].join('') },
         )
@@ -835,6 +932,7 @@ workflow ATACSEQ {
             ch_picardcollectmultiplemetrics_multiqc.collect{it[1]}.ifEmpty([]),
 
             ch_preseq_multiqc.collect{it[1]}.ifEmpty([]),
+
             ch_deeptoolsplotprofile_multiqc.collect{it[1]}.ifEmpty([]),
             ch_deeptoolsplotfingerprint_multiqc.collect{it[1]}.ifEmpty([]),
 

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -11,7 +11,7 @@ def valid_params = [
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 
 // Validate input parameters
-WorkflowAtacseq.initialise(params, log, valid_params))
+WorkflowAtacseq.initialise(params, log, valid_params)
 
 // Check input path parameters to see if they exist
 def checkPathParamList = [

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -131,8 +131,11 @@ include { HOMER_ANNOTATEPEAKS as HOMER_ANNOTATEPEAKS_CONSENSUS_REP } from '../mo
 // SUBWORKFLOW: Consisting entirely of nf-core/modules
 //
 
-include { FASTQC_TRIMGALORE      } from '../subworkflows/nf-core/fastqc_trimgalore'
-include { ALIGN_BWA_MEM          } from '../subworkflows/nf-core/align_bwa_mem'
+include { FASTQC_TRIMGALORE } from '../subworkflows/nf-core/fastqc_trimgalore'
+include { ALIGN_BWA_MEM     } from '../subworkflows/nf-core/align_bwa_mem'
+include { ALIGN_BOWTIE2     } from '../subworkflows/nf-core/align_bowtie2'
+include { ALIGN_CHROMAP     } from '../subworkflows/nf-core/align_chromap'
+include { ALIGN_STAR        } from '../subworkflows/nf-core/align_star'
 include { MARK_DUPLICATES_PICARD as MARK_DUPLICATES_PICARD_LIB } from '../subworkflows/nf-core/mark_duplicates_picard'
 include { MARK_DUPLICATES_PICARD as MARK_DUPLICATES_PICARD_REP } from '../subworkflows/nf-core/mark_duplicates_picard'
 

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -941,7 +941,7 @@ workflow ATACSEQ {
 
             ch_custompeaks_frip_multiqc.collect{it[1]}.ifEmpty([]),
             ch_custompeaks_count_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_plothomerannotatepeaks_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_plothomerannotatepeaks_multiqc.collect().ifEmpty([]),
             ch_subreadfeaturecounts_multiqc.collect{it[1]}.ifEmpty([]),
             // path ('macs/consensus/*') from ch_macs_consensus_deseq_mqc.collect().ifEmpty([])
 
@@ -952,7 +952,7 @@ workflow ATACSEQ {
 
             ch_custompeaks_frip_multiqc_rep.collect{it[1]}.ifEmpty([]),
             ch_custompeaks_count_multiqc_rep.collect{it[1]}.ifEmpty([]),
-            ch_plothomerannotatepeaks_multiqc_rep.collect{it[1]}.ifEmpty([]),
+            ch_plothomerannotatepeaks_multiqc_rep.collect().ifEmpty([]),
             ch_subreadfeaturecounts_multiqc_rep.collect{it[1]}.ifEmpty([]),
 
             ch_deseq2_lib_pca_multiqc.collect().ifEmpty([]),


### PR DESCRIPTION
# Fix issue with Homer inputs to MultiQC

There were two channels supplied as MultiQC inputs that were pulling incorrect results. Previously:

```groovy
        MULTIQC (
            ch_multiqc_config,
            ch_multiqc_custom_config.collect().ifEmpty([]),
...
            ch_plothomerannotatepeaks_multiqc.collect{it[1]}.ifEmpty([]),
...
            ch_plothomerannotatepeaks_multiqc_rep.collect{it[1]}.ifEmpty([]),
...
            ch_deseq2_rep_pca_multiqc.collect().ifEmpty([]),
            ch_deseq2_rep_clustering_multiqc.collect().ifEmpty([])
        )
```

Both `ch_plothomerannotatepeaks_multiqc` and `ch_plothomerannotatepeaks_multiqc_rep` are channels that emit a single item (a `path`). Were were pulling out the second element `it[1]` but would resolve to a path element (the second directory in the path). I think that the original author may have expected that the channel would be a tuple and that the second element would be the path.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [X] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)