### PR TITLE
Correct errors in staging Homer inputs for MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unpublished Version / DEV]
 
+- Fix handling of Homer outputs staged for MultiQC
+
 ### Major enhancements
 
 - Pipeline has been re-implemented in [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html)

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -943,7 +943,7 @@ workflow ATACSEQ {
 
             ch_custompeaks_frip_multiqc.collect{it[1]}.ifEmpty([]),
             ch_custompeaks_count_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_plothomerannotatepeaks_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_plothomerannotatepeaks_multiqc.collect().ifEmpty([]),
             ch_subreadfeaturecounts_multiqc.collect{it[1]}.ifEmpty([]),
             // path ('macs/consensus/*') from ch_macs_consensus_deseq_mqc.collect().ifEmpty([])
 
@@ -954,7 +954,7 @@ workflow ATACSEQ {
 
             ch_custompeaks_frip_multiqc_rep.collect{it[1]}.ifEmpty([]),
             ch_custompeaks_count_multiqc_rep.collect{it[1]}.ifEmpty([]),
-            ch_plothomerannotatepeaks_multiqc_rep.collect{it[1]}.ifEmpty([]),
+            ch_plothomerannotatepeaks_multiqc_rep.collect().ifEmpty([]),
             ch_subreadfeaturecounts_multiqc_rep.collect{it[1]}.ifEmpty([]),
 
             ch_deseq2_lib_pca_multiqc.collect().ifEmpty([]),


### PR DESCRIPTION
# Fix issue with Homer inputs to MultiQC

There were two channels supplied as MultiQC inputs that were pulling incorrect results. Previously:

```groovy
        MULTIQC (
            ch_multiqc_config,
            ch_multiqc_custom_config.collect().ifEmpty([]),
...
            ch_plothomerannotatepeaks_multiqc.collect{it[1]}.ifEmpty([]),
...
            ch_plothomerannotatepeaks_multiqc_rep.collect{it[1]}.ifEmpty([]),
...
            ch_deseq2_rep_pca_multiqc.collect().ifEmpty([]),
            ch_deseq2_rep_clustering_multiqc.collect().ifEmpty([])
        )
```

Both `ch_plothomerannotatepeaks_multiqc` and `ch_plothomerannotatepeaks_multiqc_rep` are channels that emit a single item (a `path`). Were were pulling out the second element `it[1]` but would resolve to a path element (the second directory in the path). I think that the original author may have expected that the channel would be a tuple and that the second element would be the path.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [X] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)