### PR TITLE
Mito name fix

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -707,10 +707,7 @@ if (!params.skip_deseq2_qc) {
 if (!params.skip_ataqv) {
     process {
         withName: 'ATAQV_ATAQV' {
-            ext.args   = [
-                '--ignore-read-groups',
-                params.mito_name ? "--mitochondrial-reference-name ${params.mito_name}" : ''
-            ].join(' ').trim()
+            ext.args   = '--ignore-read-groups'
             publishDir = [
                 path: { [
                     "${params.outdir}/${params.aligner}/mergedLibrary/ataqv",

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "ataqv/ataqv": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "56421e1a812bc2f9e77dbe9f297e9d9c580cb8a5"
                     },
                     "ataqv/mkarv": {
                         "branch": "master",

--- a/modules/nf-core/ataqv/ataqv/main.nf
+++ b/modules/nf-core/ataqv/ataqv/main.nf
@@ -10,6 +10,7 @@ process ATAQV_ATAQV {
     input:
     tuple val(meta), path(bam), path(bai), path(peak_file)
     val organism
+    val mito_name
     path tss_file
     path excl_regs_file
     path autosom_ref_file
@@ -24,6 +25,7 @@ process ATAQV_ATAQV {
 
     script:
     def args = task.ext.args ?: ''
+    def mito = mito_name ? "--mitochondrial-reference-name ${mito_name}" : ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def peak        = peak_file        ? "--peak-file $peak_file"                       : ''
     def tss         = tss_file         ? "--tss-file $tss_file"                         : ''
@@ -32,6 +34,7 @@ process ATAQV_ATAQV {
     """
     ataqv \\
         $args \\
+        $mito \\
         $peak \\
         $tss \\
         $excl_regs \\

--- a/modules/nf-core/ataqv/ataqv/meta.yml
+++ b/modules/nf-core/ataqv/ataqv/meta.yml
@@ -32,6 +32,9 @@ input:
   - organism:
       type: string
       description: The subject of the experiment, which determines the list of autosomes (see "Reference Genome Configuration" section at https://github.com/ParkerLab/ataqv).
+  - mito_name:
+      type: string
+      description: Name of the mitochondrial sequence.
   - tss_file:
       type: file
       description: A BED file of transcription start sites for the experiment organism. If supplied, a TSS enrichment score will be calculated according to the ENCODE data standards. This calculation requires that the BAM file of alignments be indexed.

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -600,6 +600,7 @@ workflow ATACSEQ {
         ATAQV_ATAQV (
             ch_bam_peak,
             'NA',
+            params.mito_name,
             PREPARE_GENOME.out.tss_bed,
             [],
             PREPARE_GENOME.out.autosomes


### PR DESCRIPTION
# Description

The ATAQV_ATAQV process can add the `--mitochondrial-reference-name` argument when the mitochondrial name is known.

In nf-core/atacseq, (prior to this PR) the we supply this via the ext.args configuration option, where it relies on the `params.mito_name` configuration value to be available when this configuration is resolved:
```
ext.args   = [
    '--ignore-read-groups',
    params.mito_name ? "--mitochondrial-reference-name ${params.mito_name}" : ''
].join(' ').trim()
``` 

The `params.mito_name` value is set inside [main.nf#L29](https://github.com/nf-core/atacseq/blob/6b95c43e11f6e32c9de29baa4370ede6dac67a09/main.nf#L29), but this happens *after* the ext.args is resolved by which time it is too late.

This PR pulls the updated ATAQV_ATAQV which provides the opportunity to supply the mito_name as an input to the process.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [x] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)