### PR TITLE
Get read of copyTo for publishing genome fasta

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -985,12 +985,20 @@ if (!params.skip_igv) {
     process {
         withName: 'IGV' {
             publishDir = [
+                [
                     path: { [
                         "${params.outdir}/igv",
                         params.narrow_peak? '/narrowPeak' : '/broadPeak'
                     ].join('') },
                     mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    pattern: '*.{txt,xml}'
+                ],
+                [
+                    path: { "${params.outdir}/genome" },
+                    mode: params.publish_dir_mode,
+                    pattern: '*.{fa,fasta}',
+                    enabled: params.save_reference
+                ]
             ]
         }
     }

--- a/modules/local/igv.nf
+++ b/modules/local/igv.nf
@@ -27,6 +27,7 @@ process IGV {
     output:
     path "*files.txt"  , emit: txt
     path "*.xml"       , emit: xml
+    path fasta         , emit: fasta // Publish fasta file while copyTo fails when the source and destination buckets are in different regions
     path "versions.yml", emit: versions
 
     script: // scripts are bundled with the pipeline in nf-core/atacseq/bin/

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -46,12 +46,6 @@ workflow PREPARE_GENOME {
         ch_fasta = file(params.fasta)
     }
 
-    // Make fasta file available if reference saved or IGV is run
-    if (params.save_reference || !params.skip_igv) {
-        file("${params.outdir}/genome/").mkdirs()
-        ch_fasta.copyTo("${params.outdir}/genome/")
-    }
-
     //
     // Uncompress GTF annotation file or create from GFF3 if required
     //


### PR DESCRIPTION
Related to #218. As reported by @robsyme on slack `copyTo` fails when the source and destination buckets are in different regions when running the pipeline in s3 and thus [this](https://github.com/nf-core/atacseq/blob/d5a816c973826ac45927c813a0a74f2fc15d7b49/subworkflows/local/prepare_genome.nf#L49-L53) code fails. This might be solved upstream in Nextflow itself but in the meanwhile, publishing the `fasta` file by the `IGV` process itself solves the issue.