### PR TITLE
retain optional columns from sample sheet

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -105,6 +105,17 @@ def check_samplesheet(file_in, file_out):
                 sample_info = ["1", fastq_1, fastq_2]
             else:
                 print_error("Invalid combination of columns provided!", "Line", line)
+                
+            ## Add additional sample_info columns if optional columns exist
+            if len(lspl) > len(lspl[: len(HEADER)]):
+                add_cols = []
+                for col in header[len(HEADER):]: # collect additional column names
+                    if col in add_cols:
+                        print_error("Duplicate columns were specified!", "Line", line)
+                    else:
+                        add_cols.append(col)
+                for col in lspl[len(HEADER):]: # add additional column values to sample_info
+                    sample_info.append(col)
 
             ## Create sample mapping dictionary = {sample: [[ single_end, fastq_1, fastq_2 ]]}
             if sample not in sample_mapping_dict:
@@ -128,6 +139,7 @@ def check_samplesheet(file_in, file_out):
                         "fastq_1",
                         "fastq_2",
                     ]
+                    + add_cols
                 )
                 + "\n"
             )

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -107,8 +107,8 @@ def check_samplesheet(file_in, file_out):
                 print_error("Invalid combination of columns provided!", "Line", line)
                 
             ## Add additional sample_info columns if optional columns exist
+            add_cols = []
             if len(lspl) > len(lspl[: len(HEADER)]):
-                add_cols = []
                 for col in header[len(HEADER):]: # collect additional column names
                     if col in add_cols:
                         print_error("Duplicate columns were specified!", "Line", line)

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -109,12 +109,14 @@ def check_samplesheet(file_in, file_out):
             ## Add additional sample_info columns if optional columns exist
             add_cols = []
             if len(lspl) > len(lspl[: len(HEADER)]):
-                for col in header[len(HEADER):]: # collect additional column names
+                for col in header[len(HEADER) :]: # collect additional column names
                     if col in add_cols:
                         print_error("Duplicate columns were specified!", "Line", line)
                     else:
                         add_cols.append(col)
-                for col in lspl[len(HEADER):]: # add additional column values to sample_info
+                for col in lspl[
+                    len(HEADER) :
+                ]:  # add additional column values to sample_info
                     sample_info.append(col)
 
             ## Create sample mapping dictionary = {sample: [[ single_end, fastq_1, fastq_2 ]]}


### PR DESCRIPTION
 I gave it a go in adjusting samplesheet_check.py and input_check.nf to make sure additional columns are retained in the input samplesheet and the meta map. Happy to keep refining this if it makes sense. 
# nf-core/atacseq pull request

Many thanks for contributing to nf-core/atacseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

-  [ ] 1) Modified check_samplesheet.py to retain optional additional columns in the input sample sheet csv in the downstream sample sheet and 2) retain these additional columns in the "meta" map so that they can possibly be used downstream 
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)