### PR TITLE
Computemarix tssfix 193

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -483,9 +483,19 @@ if (!params.skip_preseq) {
 
 if (!params.skip_plot_profile) {
     process {
-        withName: 'DEEPTOOLS_COMPUTEMATRIX' {
-            ext.args   = 'scale-regions --regionBodyLength 1000 --beforeRegionStartLength 3000 --afterRegionStartLength 3000 --skipZeros --smartLabels'
+        withName: 'DEEPTOOLS_COMPUTEMATRIX_SCALE_REGIONS' {
+            ext.args   = 'scale-regions --regionBodyLength 1000 --beforeRegionStartLength 3000 --afterRegionStartLength 3000 --missingDataAsZero --skipZeros --smartLabels'
             ext.prefix = { "${meta.id}.mLb.clN" }
+            publishDir = [
+                path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            ]
+        }
+
+        withName: 'DEEPTOOLS_COMPUTEMATRIX_REFERENCE_POINT' {
+            ext.args   = 'reference-point --missingDataAsZero --skipZeros --smartLabels --upstream 3000 --downstream 3000'
+            ext.prefix = { "${meta.id}.mLb.clN.point" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
                 mode: params.publish_dir_mode,


### PR DESCRIPTION
# TSS heatmap inconsistency Fix

Fixes for the Deeptools matrix computation which flows to heatmap generation, fixing issue https://github.com/nf-core/atacseq/issues/193.

Previously, we were passing the gene bed file, when we should have been passing the tss bed file. The TSS bed file as it is currently generated produces a list of regions 1bp wide, specifying just the TSS start site. These regions are too small for the deeptools computeMatrix step to handle. By default, the minimum bin width is 10bp and regions smaller than this are discarded by deeptools. This PR also includes an awk snippet that expands any regions smaller than 10bp in the bed file to meet the 10bp window size minimum.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If necessary, also make a PR on the [nf-core/atacseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/atacseq)
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [X] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)