### PR TITLE
Fix publishing options for all files relative to v1.2.2

### DIFF
--- a/bin/deseq2_qc.r
+++ b/bin/deseq2_qc.r
@@ -224,7 +224,7 @@ normFactors <- sizeFactors(dds)
 save(normFactors, file=NormFactorsFile)
 
 for (name in names(sizeFactors(dds))) {
-    sizeFactorFile <- paste(SizeFactorsDir,name, ".txt", sep="")
+    sizeFactorFile <- paste(SizeFactorsDir,name, ".size_factors.txt", sep="")
     write(as.numeric(sizeFactors(dds)[name]), file=sizeFactorFile)
 }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -199,7 +199,7 @@ process {
     withName: 'NFCORE_ATACSEQ:ATACSEQ:.*:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT' {
         ext.prefix = { "${meta.id}.Lb.sorted" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/samtools" },
+            path: { "${params.outdir}/${params.aligner}/library" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             enabled: params.save_align_intermeds
@@ -209,7 +209,7 @@ process {
     withName: 'NFCORE_ATACSEQ:ATACSEQ:.*:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX' {
         ext.prefix = { "${meta.id}.Lb.sorted" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/samtools" },
+            path: { "${params.outdir}/${params.aligner}/library" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             enabled: params.save_align_intermeds
@@ -217,7 +217,7 @@ process {
     }
 
     withName: 'NFCORE_ATACSEQ:ATACSEQ:.*:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_.*' {
-        ext.prefix = { "${meta.id}.Lb.sorted" }
+        ext.prefix = { "${meta.id}.Lb.sorted.bam" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/library/samtools_stats" },
             mode: params.publish_dir_mode,
@@ -368,7 +368,7 @@ process {
     }
 
     withName: '.*:MERGED_LIBRARY_MARKDUPLICATES_PICARD:BAM_STATS_SAMTOOLS:.*' {
-        ext.prefix = { "${meta.id}.mLb.mkD.sorted" }
+        ext.prefix = { "${meta.id}.mLb.mkD.sorted.bam" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/merged_library/samtools_stats" },
             mode: params.publish_dir_mode,
@@ -390,7 +390,6 @@ process {
             path: { "${params.outdir}/${params.aligner}/merged_library" },
             mode: params.publish_dir_mode,
             pattern: '*.mLb.flT.sorted.bam',
-
             enabled: params.save_align_intermeds
         ]
     }
@@ -424,7 +423,7 @@ process {
     }
 
     withName: '.*:MERGED_LIBRARY_FILTER_BAM:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:.*' {
-        ext.prefix = { "${meta.id}.mLb.clN.sorted" }
+        ext.prefix = { "${meta.id}.mLb.clN.sorted.bam" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/merged_library/samtools_stats" },
             mode: params.publish_dir_mode,
@@ -467,7 +466,7 @@ if (!params.skip_picard_metrics) {
     process {
         withName: 'MERGED_LIBRARY_PICARD_COLLECTMULTIPLEMETRICS' {
             ext.args   = '--VALIDATION_STRINGENCY LENIENT --TMP_DIR tmp'
-            ext.prefix = { "${meta.id}.mLb.clN.sorted" }
+            ext.prefix = { "${meta.id}.mLb.clN" }
             publishDir = [
                 [
                     path: { "${params.outdir}/${params.aligner}/merged_library/picard_metrics" },
@@ -488,7 +487,7 @@ if (!params.skip_preseq) {
     process {
         withName: 'MERGED_LIBRARY_PRESEQ_LCEXTRAP' {
             ext.args   = '-verbose -bam -seed 1'
-            ext.prefix = { "${meta.id}.mLb.clN" }
+            ext.prefix = { "${meta.id}.mLb.mkD" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/preseq" },
                 mode: params.publish_dir_mode,
@@ -502,7 +501,7 @@ if (!params.skip_plot_profile) {
     process {
         withName: 'DEEPTOOLS_COMPUTEMATRIX_SCALE_REGIONS' {
             ext.args   = 'scale-regions --regionBodyLength 1000 --beforeRegionStartLength 3000 --afterRegionStartLength 3000 --missingDataAsZero --skipZeros --smartLabels'
-            ext.prefix = { "${meta.id}.mLb.clN" }
+            ext.prefix = { "${meta.id}.mLb.clN.scale_regions" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
                 mode: params.publish_dir_mode,
@@ -512,7 +511,7 @@ if (!params.skip_plot_profile) {
 
         withName: 'DEEPTOOLS_COMPUTEMATRIX_REFERENCE_POINT' {
             ext.args   = 'reference-point --missingDataAsZero --skipZeros --smartLabels --upstream 3000 --downstream 3000'
-            ext.prefix = { "${meta.id}.mLb.clN.point" }
+            ext.prefix = { "${meta.id}.mLb.clN.reference_point" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
                 mode: params.publish_dir_mode,
@@ -521,7 +520,7 @@ if (!params.skip_plot_profile) {
         }
 
         withName: 'DEEPTOOLS_PLOTPROFILE' {
-            ext.prefix = { "${meta.id}.mLb.clN" }
+            ext.prefix = { "${meta.id}.mLb.clN.reference_point" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
                 mode: params.publish_dir_mode,
@@ -530,7 +529,7 @@ if (!params.skip_plot_profile) {
         }
 
         withName: 'DEEPTOOLS_PLOTHEATMAP' {
-            ext.prefix = { "${meta.id}.mLb.clN" }
+            ext.prefix = { "${meta.id}.mLb.clN.scale_regions" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/deeptools/plotprofile" },
                 mode: params.publish_dir_mode,
@@ -570,6 +569,7 @@ process {
             params.macs_pvalue      ? "--pvalue ${params.macs_pvalue}" : '',
             params.macs_fdr         ? "--qvalue ${params.macs_fdr}" : ''
         ].join(' ').trim()
+        ext.prefix = { "${meta.id}.mLb.clN" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
             mode: params.publish_dir_mode,
@@ -586,6 +586,7 @@ process {
     }
 
     withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:MULTIQC_CUSTOM_PEAKS' {
+        ext.prefix = { "${meta.id}.mLb.clN_peaks" }
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
             mode: params.publish_dir_mode,
@@ -598,6 +599,7 @@ if (!params.skip_peak_annotation) {
     process {
         withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:HOMER_ANNOTATEPEAKS' {
             ext.args   = '-gid'
+            ext.prefix = { "${meta.id}.mLb.clN_peaks" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                 mode: params.publish_dir_mode,
@@ -609,7 +611,7 @@ if (!params.skip_peak_annotation) {
     if (!params.skip_peak_qc) {
         process {
             withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:PLOT_MACS2_QC' {
-                ext.args   = '-o ./ -p macs2_peak'
+                ext.args   = '-o ./ -p macs2_peak.mLb.clN'
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                     mode: params.publish_dir_mode,
@@ -619,7 +621,7 @@ if (!params.skip_peak_annotation) {
 
             withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:PLOT_HOMER_ANNOTATEPEAKS' {
                 ext.args   = '-o ./'
-                ext.prefix = 'macs2_annotatePeaks'
+                ext.prefix = 'macs2_annotatePeaks.mLb.clN'
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                     mode: params.publish_dir_mode,
@@ -634,6 +636,7 @@ if (!params.skip_consensus_peaks) {
     process {
         withName: '.*:MERGED_LIBRARY_CONSENSUS_PEAKS:MACS2_CONSENSUS' {
             ext.args   = "--min_replicates ${params.min_reps_consensus}"
+            ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
@@ -643,6 +646,7 @@ if (!params.skip_consensus_peaks) {
 
         withName: '.*:MERGED_LIBRARY_CONSENSUS_PEAKS:SUBREAD_FEATURECOUNTS'  {
             ext.args   = '-F SAF -O --fracOverlap 0.2'
+            ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
@@ -660,6 +664,7 @@ if (!params.skip_consensus_peaks) {
                     '--count_col 7',
                     params.deseq2_vst ? '--vst TRUE' : ''
                 ].join(' ').trim()
+                ext.prefix = { "${meta.id}.mLb.clN" }
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/deseq2" },
                     mode: params.publish_dir_mode,
@@ -674,6 +679,7 @@ if (!params.skip_peak_annotation) {
     process {
         withName: '.*:MERGED_LIBRARY_CONSENSUS_PEAKS:HOMER_ANNOTATEPEAKS' {
             ext.args   = '-gid'
+            ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
@@ -741,6 +747,7 @@ if (!params.skip_merge_replicates) {
         }
 
         withName: '.*:MERGED_REPLICATE_MARKDUPLICATES_PICARD:BAM_STATS_SAMTOOLS:.*' {
+            ext.prefix = { "${meta.id}.mRp.clN.sorted.bam" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_replicate/samtools_stats" },
                 mode: params.publish_dir_mode,
@@ -789,6 +796,7 @@ if (!params.skip_merge_replicates) {
                 params.narrow_peak      ? '' : "--broad --broad-cutoff ${params.broad_cutoff}",
                 params.save_macs_pileup ? '--bdg --SPMR' : '',
             ].join(' ').trim()
+            ext.prefix = { "${meta.id}.mRp.clN" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                 mode: params.publish_dir_mode,
@@ -805,6 +813,7 @@ if (!params.skip_merge_replicates) {
         }
 
         withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:MULTIQC_CUSTOM_PEAKS' {
+            ext.prefix = { "${meta.id}.mRp.clN_peaks" }
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                 mode: params.publish_dir_mode,
@@ -817,6 +826,7 @@ if (!params.skip_merge_replicates) {
         process {
             withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:HOMER_ANNOTATEPEAKS' {
                 ext.args   = '-gid'
+                ext.prefix = { "${meta.id}.mRp.clN_peaks" }
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
                     mode: params.publish_dir_mode,
@@ -828,7 +838,7 @@ if (!params.skip_merge_replicates) {
         if (!params.skip_peak_qc) {
             process {
                 withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:PLOT_MACS2_QC' {
-                    ext.args   = '-o ./ -p macs2_peak'
+                    ext.args   = '-o ./ -p macs2_peak.mRp.clN'
                     publishDir = [
                         path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                         mode: params.publish_dir_mode,
@@ -838,7 +848,7 @@ if (!params.skip_merge_replicates) {
 
                 withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:PLOT_HOMER_ANNOTATEPEAKS' {
                     ext.args   = '-o ./'
-                    ext.prefix = 'macs2_annotatePeaks'
+                    ext.prefix = 'macs2_annotatePeaks.mRp.clN'
                     publishDir = [
                         path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
                         mode: params.publish_dir_mode,
@@ -852,6 +862,7 @@ if (!params.skip_merge_replicates) {
     if (!params.skip_consensus_peaks) {
         process {
             withName: '.*:MERGED_REPLICATE_CONSENSUS_PEAKS:MACS2_CONSENSUS' {
+                ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,
@@ -861,6 +872,7 @@ if (!params.skip_merge_replicates) {
 
             withName: '.*:MERGED_REPLICATE_CONSENSUS_PEAKS:SUBREAD_FEATURECOUNTS'  {
                 ext.args   = '-F SAF -O --fracOverlap 0.2'
+                ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,
@@ -878,6 +890,7 @@ if (!params.skip_merge_replicates) {
                         '--count_col 7',
                         params.deseq2_vst ? '--vst TRUE' : ''
                     ].join(' ').trim()
+                    ext.prefix = { "${meta.id}.mRp.clN" }
                     publishDir = [
                         path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/deseq2" },
                         mode: params.publish_dir_mode,
@@ -892,6 +905,7 @@ if (!params.skip_merge_replicates) {
         process {
             withName: '.*:MERGED_REPLICATE_CONSENSUS_PEAKS:HOMER_ANNOTATEPEAKS' {
                 ext.args   = '-gid'
+                ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,

--- a/modules.json
+++ b/modules.json
@@ -8,172 +8,252 @@
                     "ataqv/ataqv": {
                         "branch": "master",
                         "git_sha": "56421e1a812bc2f9e77dbe9f297e9d9c580cb8a5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "ataqv/mkarv": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "fastq_align_bowtie2"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_align_bowtie2"
+                        ]
                     },
                     "bowtie2/build": {
                         "branch": "master",
                         "git_sha": "e797efb47b0d3b2124753beb55dc83ab9512bceb",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bwa/index": {
                         "branch": "master",
                         "git_sha": "9518fa4f65f3fb8cde24fde7d40333b39ec8fd65",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bwa/mem": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "fastq_align_bwa"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_align_bwa"
+                        ]
                     },
                     "chromap/chromap": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "fastq_align_chromap"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_align_chromap"
+                        ]
                     },
                     "chromap/index": {
                         "branch": "master",
                         "git_sha": "3a8e3ca607132a468c07c69aaa3bccd55eb983b8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "8022c68e7403eecbd8ba9c49496f69f8c49d50f0",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "deeptools/computematrix": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "deeptools/plotfingerprint": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "deeptools/plotheatmap": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "deeptools/plotprofile": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
-                        "git_sha": "3dd73937b084b547f9272bc901e0f120a7913fd8",
-                        "installed_by": ["modules", "fastq_fastqc_umitools_trimgalore"]
+                        "git_sha": "810e8f2603ec38401d49a4aaed06f6d058745552",
+                        "installed_by": [
+                            "modules",
+                            "fastq_fastqc_umitools_trimgalore"
+                        ]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "homer/annotatepeaks": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "khmer/uniquekmers": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "macs2/callpeak": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "picard/collectmultiplemetrics": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "picard/markduplicates": {
                         "branch": "master",
                         "git_sha": "eca65aa4a5e2e192ac44d6962c8f9260f314ffb8",
-                        "installed_by": ["modules", "bam_markduplicates_picard"]
+                        "installed_by": [
+                            "modules",
+                            "bam_markduplicates_picard"
+                        ]
                     },
                     "picard/mergesamfiles": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "preseq/lcextrap": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "bam_stats_samtools"]
+                        "installed_by": [
+                            "modules",
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "bam_stats_samtools"]
+                        "installed_by": [
+                            "modules",
+                            "bam_stats_samtools"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "bam_markduplicates_picard", "bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "modules",
+                            "bam_markduplicates_picard",
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "bam_sort_stats_samtools"]
+                        "installed_by": [
+                            "modules",
+                            "bam_sort_stats_samtools"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": ["modules", "bam_stats_samtools"]
+                        "installed_by": [
+                            "modules",
+                            "bam_stats_samtools"
+                        ]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "b51a69e30973c71950225c817ad07a3337d22c40",
-                        "installed_by": ["modules", "fastq_fastqc_umitools_trimgalore"]
+                        "installed_by": [
+                            "modules",
+                            "fastq_fastqc_umitools_trimgalore"
+                        ]
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore"]
+                        "installed_by": [
+                            "fastq_fastqc_umitools_trimgalore"
+                        ]
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -182,7 +262,9 @@
                     "bam_markduplicates_picard": {
                         "branch": "master",
                         "git_sha": "6daac2bc63f4847e0c7cc661f4f5b043ac13faaf",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "bam_sort_stats_samtools": {
                         "branch": "master",
@@ -197,27 +279,39 @@
                     "bam_stats_samtools": {
                         "branch": "master",
                         "git_sha": "92eb5091ae5368a60cda58b3a0ced8b36d715b0f",
-                        "installed_by": ["bam_markduplicates_picard", "bam_sort_stats_samtools", "subworkflows"]
+                        "installed_by": [
+                            "bam_markduplicates_picard",
+                            "bam_sort_stats_samtools",
+                            "subworkflows"
+                        ]
                     },
                     "fastq_align_bowtie2": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_align_bwa": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_align_chromap": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "fastq_fastqc_umitools_trimgalore": {
                         "branch": "master",
                         "git_sha": "b51a69e30973c71950225c817ad07a3337d22c40",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,252 +8,172 @@
                     "ataqv/ataqv": {
                         "branch": "master",
                         "git_sha": "56421e1a812bc2f9e77dbe9f297e9d9c580cb8a5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "ataqv/mkarv": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "fastq_align_bowtie2"
-                        ]
+                        "installed_by": ["modules", "fastq_align_bowtie2"]
                     },
                     "bowtie2/build": {
                         "branch": "master",
                         "git_sha": "e797efb47b0d3b2124753beb55dc83ab9512bceb",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bwa/index": {
                         "branch": "master",
                         "git_sha": "9518fa4f65f3fb8cde24fde7d40333b39ec8fd65",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bwa/mem": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "fastq_align_bwa"
-                        ]
+                        "installed_by": ["modules", "fastq_align_bwa"]
                     },
                     "chromap/chromap": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "fastq_align_chromap"
-                        ]
+                        "installed_by": ["modules", "fastq_align_chromap"]
                     },
                     "chromap/index": {
                         "branch": "master",
                         "git_sha": "3a8e3ca607132a468c07c69aaa3bccd55eb983b8",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "8022c68e7403eecbd8ba9c49496f69f8c49d50f0",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/getchromsizes": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "deeptools/computematrix": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "deeptools/plotfingerprint": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "deeptools/plotheatmap": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "deeptools/plotprofile": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "810e8f2603ec38401d49a4aaed06f6d058745552",
-                        "installed_by": [
-                            "modules",
-                            "fastq_fastqc_umitools_trimgalore"
-                        ]
+                        "installed_by": ["modules", "fastq_fastqc_umitools_trimgalore"]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "homer/annotatepeaks": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "khmer/uniquekmers": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "macs2/callpeak": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "picard/collectmultiplemetrics": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "picard/markduplicates": {
                         "branch": "master",
                         "git_sha": "eca65aa4a5e2e192ac44d6962c8f9260f314ffb8",
-                        "installed_by": [
-                            "modules",
-                            "bam_markduplicates_picard"
-                        ]
+                        "installed_by": ["modules", "bam_markduplicates_picard"]
                     },
                     "picard/mergesamfiles": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "preseq/lcextrap": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["modules", "bam_stats_samtools"]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["modules", "bam_stats_samtools"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "bam_markduplicates_picard",
-                            "bam_sort_stats_samtools"
-                        ]
+                        "installed_by": ["modules", "bam_markduplicates_picard", "bam_sort_stats_samtools"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "bam_sort_stats_samtools"
-                        ]
+                        "installed_by": ["modules", "bam_sort_stats_samtools"]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "cf5b9c30a2adacc581793afb79fae5f5b50bed01",
-                        "installed_by": [
-                            "modules",
-                            "bam_stats_samtools"
-                        ]
+                        "installed_by": ["modules", "bam_stats_samtools"]
                     },
                     "subread/featurecounts": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "trimgalore": {
                         "branch": "master",
                         "git_sha": "b51a69e30973c71950225c817ad07a3337d22c40",
-                        "installed_by": [
-                            "modules",
-                            "fastq_fastqc_umitools_trimgalore"
-                        ]
+                        "installed_by": ["modules", "fastq_fastqc_umitools_trimgalore"]
                     },
                     "ucsc/bedgraphtobigwig": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "fastq_fastqc_umitools_trimgalore"
-                        ]
+                        "installed_by": ["fastq_fastqc_umitools_trimgalore"]
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },
@@ -262,9 +182,7 @@
                     "bam_markduplicates_picard": {
                         "branch": "master",
                         "git_sha": "6daac2bc63f4847e0c7cc661f4f5b043ac13faaf",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "bam_sort_stats_samtools": {
                         "branch": "master",
@@ -279,39 +197,27 @@
                     "bam_stats_samtools": {
                         "branch": "master",
                         "git_sha": "92eb5091ae5368a60cda58b3a0ced8b36d715b0f",
-                        "installed_by": [
-                            "bam_markduplicates_picard",
-                            "bam_sort_stats_samtools",
-                            "subworkflows"
-                        ]
+                        "installed_by": ["bam_markduplicates_picard", "bam_sort_stats_samtools", "subworkflows"]
                     },
                     "fastq_align_bowtie2": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "fastq_align_bwa": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "fastq_align_chromap": {
                         "branch": "master",
                         "git_sha": "ac75f79157ecc64283a2b3a559f1ba90bc0f2259",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "fastq_fastqc_umitools_trimgalore": {
                         "branch": "master",
                         "git_sha": "b51a69e30973c71950225c817ad07a3337d22c40",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules/local/multiqc_custom_peaks.nf
+++ b/modules/local/multiqc_custom_peaks.nf
@@ -11,7 +11,7 @@ process MULTIQC_CUSTOM_PEAKS {
     path frip_score_header
 
     output:
-    tuple val(meta), path("*.peak_count_mqc.tsv"), emit: count
+    tuple val(meta), path("*.count_mqc.tsv"), emit: count
     tuple val(meta), path("*.FRiP_mqc.tsv")      , emit: frip
     path "versions.yml"                          , emit: versions
 
@@ -21,7 +21,7 @@ process MULTIQC_CUSTOM_PEAKS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    cat $peak | wc -l | awk -v OFS='\t' '{ print "${prefix}", \$1 }' | cat $peak_count_header - > ${prefix}.peak_count_mqc.tsv
+    cat $peak | wc -l | awk -v OFS='\t' '{ print "${prefix}", \$1 }' | cat $peak_count_header - > ${prefix}.count_mqc.tsv
     cat $frip_score_header $frip > ${prefix}.FRiP_mqc.tsv
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/plot_homer_annotatepeaks.nf
+++ b/modules/local/plot_homer_annotatepeaks.nf
@@ -12,24 +12,25 @@ process PLOT_HOMER_ANNOTATEPEAKS {
     val suffix
 
     output:
-    path '*.txt',        emit: txt
-    path '*.pdf',        emit: pdf
-    path '*.tsv',        emit: tsv
+    path '*.txt'       , emit: txt
+    path '*.pdf'       , emit: pdf
+    path '*.tsv'       , emit: tsv
     path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
-    script: // This script is bundled with the pipeline, in nf-core/atacseq/bin/
-    def args   = task.ext.args ?: ''
+    script: // This script is bundled with the pipeline, in nf-core/chipseq/bin/
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "annotatepeaks"
     """
     plot_homer_annotatepeaks.r \\
         -i ${annos.join(',')} \\
         -s ${annos.join(',').replaceAll("${suffix}","")} \\
+        -p $prefix \\
         $args
 
-    find ./ -type f -name "*.txt" -exec cat {} \\; | cat $mqc_header - > ${prefix}.summary_mqc.tsv
+    find ./ -type f -name "*summary.txt" -exec cat {} \\; | cat $mqc_header - > ${prefix}.summary_mqc.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -21,9 +21,15 @@ process FASTQC {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    // Make list of old name and new name pairs to use for renaming in the bash while loop
+    def old_new_pairs = reads instanceof Path || reads.size() == 1 ? [[ reads, "${prefix}.${reads.extension}" ]] : reads.withIndex().collect { entry, index -> [ entry, "${prefix}_${index + 1}.${entry.extension}" ] }
+    def rename_to = old_new_pairs*.join(' ').join(' ')
+    def renamed_files = old_new_pairs.collect{ old_name, new_name -> new_name }.join(' ')
     """
-    printf "%s\\n" $reads | while read f; do [[ \$f =~ ^${prefix}.* ]] || ln -s \$f ${prefix}_\$f ; done
-    fastqc $args --threads $task.cpus ${prefix}*
+    printf "%s %s\\n" $rename_to | while read old_name new_name; do
+        [ -f "\${new_name}" ] || ln -s \$old_name \$new_name
+    done
+    fastqc $args --threads $task.cpus $renamed_files
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Checked the published files from `dev` and 1.2.2 and amended the publishing options accordingly to make sure they match. Still a few things to iron out and check but the majority of files should be sorted now.