### PR TITLE
Modules update

### DIFF
--- a/bin/bampe_rm_orphan.py
+++ b/bin/bampe_rm_orphan.py
@@ -46,7 +46,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -63,7 +62,6 @@ def makedir(path):
 
 
 def bampe_rm_orphan(BAMIn, BAMOut, onlyFRPairs=False):
-
     ## SETUP DIRECTORY/FILE STRUCTURE
     OutDir = os.path.dirname(BAMOut)
     makedir(OutDir)
@@ -89,7 +87,6 @@ def bampe_rm_orphan(BAMIn, BAMOut, onlyFRPairs=False):
             ## FILTER FOR READS ON SAME CHROMOSOME IN FR ORIENTATION
             if onlyFRPairs:
                 if pair1.tid == pair2.tid:
-
                     ## READ1 FORWARD AND READ2 REVERSE STRAND
                     if not pair1.is_reverse and pair2.is_reverse:
                         if pair1.reference_start <= pair2.reference_start:

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -49,7 +49,6 @@ def check_samplesheet(file_in, file_out):
 
     sample_mapping_dict = {}
     with open(file_in, "r", encoding="utf-8-sig") as fin:
-
         ## Check header
         MIN_COLS = 3
         HEADER = ["sample", "fastq_1", "fastq_2", "replicate"]
@@ -135,7 +134,6 @@ def check_samplesheet(file_in, file_out):
             fout.write(",".join(HEADER + ["single_end"] + header[len(HEADER) :]) + "\n")
 
             for sample in sorted(sample_mapping_dict.keys()):
-
                 ## Check that replicate ids are in format 1..<num_replicates>
                 uniq_rep_ids = sorted(list(set(sample_mapping_dict[sample].keys())))
                 if len(uniq_rep_ids) != max(uniq_rep_ids) or 1 != min(uniq_rep_ids):

--- a/bin/get_autosomes.py
+++ b/bin/get_autosomes.py
@@ -34,7 +34,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -69,7 +68,6 @@ def makedir(path):
 
 
 def get_autosomes(FAIFile, OutFile):
-
     makedir(os.path.dirname(OutFile))
 
     ## READ IN CHROMOSOME IDS

--- a/bin/igv_files_to_session.py
+++ b/bin/igv_files_to_session.py
@@ -49,7 +49,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -66,7 +65,6 @@ def makedir(path):
 
 
 def igv_files_to_session(XMLOut, ListFile, Genome, PathPrefix=""):
-
     makedir(os.path.dirname(XMLOut))
 
     fileList = []

--- a/bin/macs2_merged_expand.py
+++ b/bin/macs2_merged_expand.py
@@ -55,7 +55,6 @@ args = argParser.parse_args()
 
 
 def makedir(path):
-
     if not len(path) == 0:
         try:
             os.makedirs(path)
@@ -78,7 +77,6 @@ def makedir(path):
 
 
 def macs2_merged_expand(MergedIntervalTxtFile, SampleNameList, OutFile, isNarrow=False, minReplicates=1):
-
     makedir(os.path.dirname(OutFile))
 
     combFreqDict = {}

--- a/modules.json
+++ b/modules.json
@@ -12,7 +12,7 @@
                     },
                     "ataqv/mkarv": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "d36a2655ce0769d7f0b604ceab08fac1d1b91bae",
                         "installed_by": ["modules"]
                     },
                     "bowtie2/align": {
@@ -157,7 +157,7 @@
                     },
                     "trimgalore": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "72ffbd7128015a1d4b65b95ff8d37be8fee2f981",
                         "installed_by": ["modules", "fastq_fastqc_umitools_trimgalore"]
                     },
                     "ucsc/bedgraphtobigwig": {
@@ -172,7 +172,7 @@
                     },
                     "untar": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "cc1f997fab6d8fde5dc0e6e2a310814df5b53ce7",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/ataqv/mkarv/main.nf
+++ b/modules/nf-core/ataqv/mkarv/main.nf
@@ -7,7 +7,7 @@ process ATAQV_MKARV {
         'quay.io/biocontainers/ataqv:1.3.0--py39hccc85d7_2' }"
 
     input:
-    path json
+    path "jsons/*"
 
     output:
     path "html"        , emit: html
@@ -24,7 +24,7 @@ process ATAQV_MKARV {
         --concurrency $task.cpus \\
         --force \\
         ./html/ \\
-        ${json.join(' ')}
+        jsons/*
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,13 +11,12 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")          , emit: log
-    path "versions.yml"                           , emit: versions
-
-    tuple val(meta), path("*unpaired*.fq.gz")     , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")               , emit: html    , optional: true
-    tuple val(meta), path("*.zip")                , emit: zip     , optional: true
+    tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
+    tuple val(meta), path("*report.txt")                        , emit: log     , optional: true
+    tuple val(meta), path("*unpaired*.fq.gz")                   , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                             , emit: html    , optional: true
+    tuple val(meta), path("*.zip")                              , emit: zip     , optional: true
+    path "versions.yml"                                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/trimgalore/meta.yml
+++ b/modules/nf-core/trimgalore/meta.yml
@@ -36,7 +36,7 @@ output:
       description: |
         List of input adapter trimmed FastQ files of size 1 and 2 for
         single-end and paired-end data, respectively.
-      pattern: "*.{fq.gz}"
+      pattern: "*{3prime,5prime,trimmed,val}*.fq.gz"
   - unpaired:
       type: file
       description: |

--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -2,7 +2,7 @@ process UNTAR {
     tag "$archive"
     label 'process_single'
 
-    conda "conda-forge::sed=4.7"
+    conda "conda-forge::sed=4.7 bioconda::grep=3.4 conda-forge::tar=1.34"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
         'ubuntu:20.04' }"
@@ -11,8 +11,8 @@ process UNTAR {
     tuple val(meta), path(archive)
 
     output:
-    tuple val(meta), path("$untar"), emit: untar
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path("$prefix"), emit: untar
+    path "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -20,30 +20,28 @@ process UNTAR {
     script:
     def args  = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
-    untar     = archive.toString() - '.tar.gz'
+    prefix    = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.baseName.toString().replaceFirst(/\.tar$/, ""))
 
     """
-    mkdir output
+    mkdir $prefix
 
     ## Ensures --strip-components only applied when top level of tar contents is a directory
-    ## If just files or multiple directories, place all in output
-    if [[ \$(tar -tzf ${archive} | grep -o -P "^.*?\\/" | uniq | wc -l) -eq 1 ]]; then
+    ## If just files or multiple directories, place all in prefix
+    if [[ \$(tar -taf ${archive} | grep -o -P "^.*?\\/" | uniq | wc -l) -eq 1 ]]; then
         tar \\
-            -C output --strip-components 1 \\
-            -xzvf \\
+            -C $prefix --strip-components 1 \\
+            -xavf \\
             $args \\
             $archive \\
             $args2
     else
         tar \\
-            -C output \\
-            -xzvf \\
+            -C $prefix \\
+            -xavf \\
             $args \\
             $archive \\
             $args2
     fi
-
-    mv output ${untar}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -52,9 +50,10 @@ process UNTAR {
     """
 
     stub:
-    untar     = archive.toString() - '.tar.gz'
+    prefix    = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.toString().replaceFirst(/\.[^\.]+(.gz)?$/, ""))
     """
-    touch $untar
+    mkdir $prefix
+    touch ${prefix}/file.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Update of nf-core/modules 

This is motivated primarily by the changes to the ATAQV_MKARV process. That process used the `join` operator to append input filenames to the mkarv command. Using the groovy join operator to explicitly print all json filenames can become extremely verbose when hundreds of json files are passed to the ATAQV_MKARV process. By staging all inputs into a known directory, we can use shell globs rather than writing all filenames.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/atacseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
