### PR TITLE
Remove glob from process definition when using ECR container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
 
       - name: Upload logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: default_run_logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,17 @@ jobs:
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
 
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        if: success() || failure()
+        with:
+          name: default_run_logs
+          path: |
+            *.log
+            *.err
+            work/
+            results/
+
   parameters:
     name: Test workflow parameters
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/atacseq') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
           path: |
             *.log
             *.err
-            work/
-            results/
 
   parameters:
     name: Test workflow parameters

--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -12,61 +12,61 @@ docker.registry = 'public.ecr.aws'
 podman.registry = 'public.ecr.aws'
 
 process {
-    withName: '.*:BAMTOOLS_FILTER' {
+    withName: 'BAMTOOLS_FILTER' {
         container = 'quay.io/biocontainers/mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:5687a7da26983502d0a8a9a6b05ed727c740ddc4-0'
     }
-    withName: '.*:BAM_REMOVE_ORPHANS' {
+    withName: 'BAM_REMOVE_ORPHANS' {
         container = 'quay.io/biocontainers/mulled-v2-57736af1eb98c01010848572c9fec9fff6ffaafd:402e865b8f6af2f3e58c6fc8d57127ff0144b2c7-0'
     }
-    withName: '.*:BOWTIE2_ALIGN' {
+    withName: 'BOWTIE2_ALIGN' {
         container = 'quay.io/biocontainers/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:a0ffedb52808e102887f6ce600d092675bf3528a-0'
     }
-    withName: '.*:BWA_MEM' {
+    withName: 'BWA_MEM' {
         container = 'quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0'
     }
-    withName: '.*:CHROMAP_CHROMAP' {
+    withName: 'CHROMAP_CHROMAP' {
         container = 'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0'
     }
-    withName: '.*:DESEQ2_QC' {
+    withName: 'DESEQ2_QC' {
         container = 'quay.io/biocontainers/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0'
     }
-    withName: '.*:FRIP_SCORE' {
+    withName: 'FRIP_SCORE' {
         container = 'quay.io/biocontainers/mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:3127fcae6b6bdaf8181e21a26ae61231030a9fcb-0'
     }
-    withName: '.*:GET_AUTOSOMES' {
+    withName: 'GET_AUTOSOMES' {
         container = 'quay.io/biocontainers/python:3.8.3'
     }
-    withName: '.*:GTF2BED' {
+    withName: 'GTF2BED' {
         container = 'quay.io/biocontainers/perl:5.26.2'
     }
-    withName: '.*:GUNZIP' {
+    withName: 'GUNZIP' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:IGV' {
+    withName: 'IGV' {
         container = 'quay.io/biocontainers/python:3.8.3'
     }
-    withName: '.*:MACS2_CONSENSUS' {
+    withName: 'MACS2_CONSENSUS' {
         container = 'quay.io/biocontainers/mulled-v2-2f48cc59b03027e31ead6d383fe1b8057785dd24:5d182f583f4696f4c4d9f3be93052811b383341f-0'
     }
-    withName: '.*:MULTIQC_CUSTOM_PEAKS' {
+    withName: 'MULTIQC_CUSTOM_PEAKS' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:PLOT_HOMER_ANNOTATEPEAKS' {
+    withName: 'PLOT_HOMER_ANNOTATEPEAKS' {
         container = 'quay.io/biocontainers/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0'
     }
-    withName: '.*:PLOT_MACS2_QC' {
+    withName: 'PLOT_MACS2_QC' {
         container = 'quay.io/biocontainers/mulled-v2-ad9dd5f398966bf899ae05f8e7c54d0fb10cdfa7:05678da05b8e5a7a5130e90a9f9a6c585b965afa-0'
     }
-    withName: '.*:SAMPLESHEET_CHECK' {
+    withName: 'SAMPLESHEET_CHECK' {
         container = 'quay.io/biocontainers/python:3.8.3'
     }
-    withName: '.*:STAR_GENOMEGENERATE' {
+    withName: 'STAR_GENOMEGENERATE' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0'
     }
-    withName: '.*:TSS_EXTRACT' {
+    withName: 'TSS_EXTRACT' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:UNTAR' {
+    withName: 'UNTAR' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
 }


### PR DESCRIPTION
Remove globs so aliasing doesn't cause process matching to fail.