### PR TITLE
Fix --blacklist error and make fasta always available for IGV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add public_aws_ecr profile for using containers hosted on ECR.
 - [[#277](https://github.com/nf-core/atacseq/issues/277)] - Fix error when using a gunziped fasta file.
 - [[#286](https://github.com/nf-core/atacseq/issues/286)] - Fix error when no `--mito_name parameter is provided.
+- [[#268](https://github.com/nf-core/atacseq/issues/268)] - Fix error when a bed file is provided using the `--blacklist` option.
+- [[#278](https://github.com/nf-core/atacseq/issues/278)] - Make genome fasta file available when `IGV` process is run.
 
 ### Parameters
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -957,8 +957,7 @@ if (!params.skip_igv) {
                 [
                     path: { "${params.outdir}/genome" },
                     mode: params.publish_dir_mode,
-                    pattern: '*.{fa,fasta}',
-                    enabled: params.save_reference
+                    pattern: '*.{fa,fasta}'
                 ]
             ]
         }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -77,7 +77,7 @@ workflow PREPARE_GENOME {
             ch_blacklist = GUNZIP_BLACKLIST ( [ [:], params.blacklist ] ).gunzip.map{ it[1] }
             ch_versions  = ch_versions.mix(GUNZIP_BLACKLIST.out.versions)
         } else {
-            ch_blacklist = Channel.of(params.blacklist)
+            ch_blacklist = Channel.value(file(params.blacklist))
         }
     }
 
@@ -104,7 +104,7 @@ workflow PREPARE_GENOME {
             ch_gene_bed = GUNZIP_GENE_BED ( [ [:], params.gene_bed ] ).gunzip.map{ it[1] }
             ch_versions = ch_versions.mix(GUNZIP_GENE_BED.out.versions)
         } else {
-            ch_gene_bed = file(params.gene_bed)
+            ch_gene_bed = Channel.value(file(params.gene_bed))
         }
     }
 
@@ -116,7 +116,7 @@ workflow PREPARE_GENOME {
             ch_tss_bed = GUNZIP_TSS_BED ( [ [:], params.tss_bed ] ).gunzip.map{ it[1] }
             ch_versions = ch_versions.mix(GUNZIP_TSS_BED.out.versions)
         } else {
-            ch_tss_bed = file(params.tss_bed)
+            ch_tss_bed = Channel.value(file(params.tss_bed))
         }
     }
 
@@ -216,7 +216,7 @@ workflow PREPARE_GENOME {
                 ch_star_index = UNTAR_STAR_INDEX ( [ [:], params.star_index ] ).untar.map{ it[1] }
                 ch_versions   = ch_versions.mix(UNTAR_STAR_INDEX.out.versions)
             } else {
-                ch_star_index = file(params.star_index)
+                ch_star_index = Channel.value(file(params.star_index))
             }
         } else {
             ch_star_index = STAR_GENOMEGENERATE ( ch_fasta, ch_gtf ).index


### PR DESCRIPTION
Fix error when bed file is provided using the `--blacklist` parameter, fixes #268
Make genome fasta file always available when `IGV` process is run (not depending of `--save_reference`), closes #278 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
