### PR TITLE
Add `ataqv_mito_reference`  parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [[#226](https://github.com/nf-core/atacseq/issues/262)] - Add `ataqv_mito_reference` parameter.
 - Optional support of control data analog to nf-core/chipseq.
 - Updated pipeline template to [nf-core/tools 2.8](https://github.com/nf-core/tools/releases/tag/2.8)
 - Add public_aws_ecr profile for using containers hosted on ECR.
@@ -15,13 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#268](https://github.com/nf-core/atacseq/issues/268)] - Fix error when a bed file is provided using the `--blacklist` option.
 - [[#278](https://github.com/nf-core/atacseq/issues/278)] - Make genome fasta file available when `IGV` process is run.
 - [[#276](https://github.com/nf-core/atacseq/issues/276)] - Bump version 1.3.1 of ataqv to fix enrichment plots rendering.
-- [[#290](https://github.com/nf-core/atacseq/issues/290)] - Fix case-sensitivity issue while sorting bedGraph
+- [[#290](https://github.com/nf-core/atacseq/issues/290)] - Fix case-sensitivity issue while sorting bedGraph.
 
 ### Parameters
 
-| Old parameter | New parameter    |
-| ------------- | ---------------- |
-|               | `--with_control` |
+| Old parameter | New parameter            |
+| ------------- | ------------------------ |
+|               | `--with_control`         |
+|               | `--ataqv_mito_reference` |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present.
 > **NB:** Parameter has been **added** if just the new parameter information is present.

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
     igenomes_base              = 's3://ngi-igenomes/igenomes'
     igenomes_ignore            = false
     save_reference             = false
+    ataqv_mito_reference       = null
 
     // Options: Trimming
     clip_r1                    = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -185,7 +185,8 @@
                 "keep_mito": {
                     "type": "boolean",
                     "description": "Reads mapping to mitochondrial contig are not filtered from alignments.",
-                    "fa_icon": "fas fa-cart-arrow-down"
+                    "fa_icon": "fas fa-cart-arrow-down",
+                    "default": false
                 },
                 "ataqv_mito_reference": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -185,7 +185,13 @@
                 "keep_mito": {
                     "type": "boolean",
                     "description": "Reads mapping to mitochondrial contig are not filtered from alignments.",
-                    "default": false
+                    "fa_icon": "fas fa-cart-arrow-down"
+                },
+                "ataqv_mito_reference": {
+                    "type": "string",
+                    "description": "Sets the value of the ataqv --mitochondrial-reference-name argument",
+                    "help_text": "By default takes the value of the mito_name parameter, if set. However, some plants and algae have chloroplast genomes in addition to a mitochondrial genome and thus mito_name can have values as multiple names that are separated by a | symbol that will break ataqv, in these cases this parameter can be used to overwrite these values.",
+                    "fa_icon": "fas fa-signature"
                 }
             }
         },

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -27,6 +27,12 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
 
+// Check ataqv_mito_reference parameter
+ataqv_mito_reference = params.ataqv_mito_reference
+if (!params.ataqv_mito_reference && params.mito_name) {
+    ataqv_mito_reference = params.mito_name
+}
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CONFIG FILES
@@ -495,7 +501,7 @@ workflow ATACSEQ {
         MERGED_LIBRARY_ATAQV_ATAQV (
             ch_bam_peaks,
             'NA',
-            params.mito_name ?: '',
+            ataqv_mito_reference ?: '',
             PREPARE_GENOME.out.tss_bed,
             [],
             PREPARE_GENOME.out.autosomes


### PR DESCRIPTION
Add `ataqv_mito_reference` parameter. This parameter enables a different mitochondrial tag to ATAQV since as explained in #262 when dealing with plant and similar organisms sometimes more than one chromosome has to be filtered out. In these cases, the chromosomes can be filtered out setting `mito_name` this way: `--mito_name='mito_id1|mito_id2' `. However, this broke ataqv since its `mitochondrial-reference-name` parameter directly took the `mito_name` value. This can be solved now by providing a different tag using  the `ataqv_mito_reference`. When not set, the behavior will be as it was until now, and `ataqv_mito_reference` will be set by default to the same value as `mito_name`.
Closes #262

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
