### PR TITLE
Increase memory and use sort in `bedtool_genomecov` process when dealing with merged replicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [[#327](https://github.com/nf-core/atacseq/issues/327)] - Consistently support `.csi` indices as alternative to `.bai` to allow SAMTOOLS_INDEX to be used with the `-c` flag.
 - [[#356](https://github.com/nf-core/atacseq/issues/356)] - Get rid of the `lib` folder and rearrange the pipeline accordingly.
-- Updated pipeline template to [nf-core/tools 2.13.1](https://github.com/nf-core/tools/releases/tag/2.13.1)
 - Updated pipeline template to [nf-core/tools 2.14.1](https://github.com/nf-core/tools/releases/tag/2.14.1)
 - [[#359](https://github.com/nf-core/atacseq/issues/359)] - Fix `--save_unaligned` description in schema.
+- [[#344](https://github.com/nf-core/atacseq/issues/344)] - Fix memory issues when sorting merged replicates after `bedtools genomecov`.
 
 ## [[2.1.2](https://github.com/nf-core/atacseq/releases/tag/2.1.2)] - 2022-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#359](https://github.com/nf-core/atacseq/issues/359)] - Fix `--save_unaligned` description in schema.
 - [[#344](https://github.com/nf-core/atacseq/issues/344)] - Fix memory issues when sorting merged replicates after `bedtools genomecov`.
 
+### Parameters
+
+| Old parameter | New parameter                    |
+| ------------- | -------------------------------- |
+|               | `--skip_merged_replicate_bigwig` |
+
+> **NB:** Parameter has been **updated** if both old and new parameter information is present.
+> **NB:** Parameter has been **added** if just the new parameter information is present.
+> **NB:** Parameter has been **removed** if parameter information isn't present.
+
 ## [[2.1.2](https://github.com/nf-core/atacseq/releases/tag/2.1.2)] - 2022-08-07
 
 ### Enhancements & fixes

--- a/conf/base.config
+++ b/conf/base.config
@@ -57,4 +57,7 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 2
     }
+    withName: '.*:MERGED_REPLICATE_BAM_TO_BIGWIG:BEDTOOLS_GENOMECOV' {
+        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
+    }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -793,6 +793,7 @@ if (!params.skip_merge_replicates) {
                     pattern: "*.txt"
                 ]
             ]
+            memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
         }
 
         withName: '.*:MERGED_REPLICATE_BAM_TO_BIGWIG:UCSC_BEDGRAPHTOBIGWIG' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -793,7 +793,6 @@ if (!params.skip_merge_replicates) {
                     pattern: "*.txt"
                 ]
             ]
-            memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
         }
 
         withName: '.*:MERGED_REPLICATE_BAM_TO_BIGWIG:UCSC_BEDGRAPHTOBIGWIG' {

--- a/modules/local/bedtools_genomecov.nf
+++ b/modules/local/bedtools_genomecov.nf
@@ -35,7 +35,7 @@ process BEDTOOLS_GENOMECOV {
         $args \\
     > tmp.bg
 
-    bedtools sort -i tmp.bg > ${prefix}.bedGraph
+    sort -k1,1 -k2,2n tmp.bg > ${prefix}.bedGraph
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,15 +60,16 @@ params {
     skip_deseq2_qc             = false
 
     // Options: QC
-    skip_qc                    = false
-    skip_fastqc                = false
-    skip_picard_metrics        = false
-    skip_preseq                = true
-    skip_plot_profile          = false
-    skip_plot_fingerprint      = false
-    skip_ataqv                 = false
-    skip_igv                   = false
-    skip_multiqc               = false
+    skip_qc                      = false
+    skip_fastqc                  = false
+    skip_picard_metrics          = false
+    skip_preseq                  = true
+    skip_plot_profile            = false
+    skip_plot_fingerprint        = false
+    skip_ataqv                   = false
+    skip_merged_replicate_bigwig = false
+    skip_igv                     = false
+    skip_multiqc                 = false
 
     // Options: Config
     bamtools_filter_pe_config  = "$projectDir/assets/bamtools_filter_pe.json"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -383,6 +383,11 @@
                     "type": "boolean",
                     "description": "Skip consensus peak generation, annotation and counting.",
                     "fa_icon": "fas fa-fast-forward"
+                },
+                "skip_merged_replicate_bigwig": {
+                    "type": "boolean",
+                    "description": "Skip generation of bigwig files for merged replicates.",
+                    "fa_icon": "fas fa-fast-forward"
                 }
             }
         },

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -562,14 +562,17 @@ workflow ATACSEQ {
         ch_markduplicates_replicate_metrics  = MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.metrics
         ch_versions = ch_versions.mix(MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.versions)
 
-        // SUBWORKFLOW: Normalised bigWig coverage tracks
-        //
-        MERGED_REPLICATE_BAM_TO_BIGWIG (
-            MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.bam.join(MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.flagstat, by: [0]),
-            ch_chrom_sizes
-        )
-        ch_ucsc_bedgraphtobigwig_replicate_bigwig = MERGED_REPLICATE_BAM_TO_BIGWIG.out.bigwig
-        ch_versions = ch_versions.mix(MERGED_REPLICATE_BAM_TO_BIGWIG.out.versions)
+        if (!params.skip_merged_replicate_bigwig) {
+            //
+            // SUBWORKFLOW: Normalised bigWig coverage tracks
+            //
+            MERGED_REPLICATE_BAM_TO_BIGWIG (
+                MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.bam.join(MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.flagstat, by: [0]),
+                ch_chrom_sizes
+            )
+            ch_ucsc_bedgraphtobigwig_replicate_bigwig = MERGED_REPLICATE_BAM_TO_BIGWIG.out.bigwig
+            ch_versions = ch_versions.mix(MERGED_REPLICATE_BAM_TO_BIGWIG.out.versions)
+        }
 
         // Create channels: [ meta, bam, ([] for control_bam) ]
         if (params.with_control) {


### PR DESCRIPTION
As reported in #344, the `bedtools sort` command in the `BEDTOOL_GENOMECOV` process is memory-greedy when dealing with merged replicates. Here, the default memory is increased and sorting is performed using the bash `sort` command which should alleviate also the problem as it takes into account the memory available and uses temporary files, if needed.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

