### PR TITLE
Remove empty path components from output paths

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -601,7 +601,7 @@ process {
         ].join(' ').trim()
         ext.prefix = { "${meta.id}.mLb.clN" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -610,7 +610,7 @@ process {
     withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:FRIP_SCORE' {
         ext.args   = '-bed -c -f 0.20'
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
             enabled: false
         ]
     }
@@ -618,7 +618,7 @@ process {
     withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:MULTIQC_CUSTOM_PEAKS' {
         ext.prefix = { "${meta.id}.mLb.clN_peaks" }
         publishDir = [
-            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+            path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -631,7 +631,7 @@ if (!params.skip_peak_annotation) {
             ext.args   = '-gid'
             ext.prefix = { "${meta.id}.mLb.clN_peaks" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -643,7 +643,7 @@ if (!params.skip_peak_annotation) {
             withName: '.*:MERGED_LIBRARY_CALL_ANNOTATE_PEAKS:PLOT_MACS2_QC' {
                 ext.args   = '-o ./ -p macs2_peak.mLb.clN'
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -653,7 +653,7 @@ if (!params.skip_peak_annotation) {
                 ext.args   = '-o ./'
                 ext.prefix = 'macs2_annotatePeaks.mLb.clN'
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -668,7 +668,7 @@ if (!params.skip_consensus_peaks) {
             ext.args   = "--min_replicates ${params.min_reps_consensus}"
             ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -678,7 +678,7 @@ if (!params.skip_consensus_peaks) {
             ext.args   = '-F SAF -O --fracOverlap 0.2'
             ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -696,7 +696,7 @@ if (!params.skip_consensus_peaks) {
                 ].join(' ').trim()
                 ext.prefix = { "${meta.id}.mLb.clN" }
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/deseq2" },
+                    path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus/deseq2" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -711,7 +711,7 @@ if (!params.skip_peak_annotation) {
             ext.args   = '-gid'
             ext.prefix = "consensus_peaks.mLb.clN"
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -724,14 +724,14 @@ if (!params.skip_ataqv) {
         withName: 'MERGED_LIBRARY_ATAQV_ATAQV' {
             ext.args   = '--ignore-read-groups'
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/ataqv/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/ataqv/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
         }
         withName: 'MERGED_LIBRARY_ATAQV_MKARV' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_library/ataqv/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                path: { "${params.outdir}/${params.aligner}/merged_library/ataqv/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -825,7 +825,7 @@ if (!params.skip_merge_replicates) {
             ].join(' ').trim()
             ext.prefix = { "${meta.id}.mRp.clN" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -834,7 +834,7 @@ if (!params.skip_merge_replicates) {
         withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:FRIP_SCORE' {
             ext.args   = '-bed -c -f 0.20'
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                 enabled: false
             ]
         }
@@ -842,7 +842,7 @@ if (!params.skip_merge_replicates) {
         withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:MULTIQC_CUSTOM_PEAKS' {
             ext.prefix = { "${meta.id}.mRp.clN_peaks" }
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -855,7 +855,7 @@ if (!params.skip_merge_replicates) {
                 ext.args   = '-gid'
                 ext.prefix = { "${meta.id}.mRp.clN_peaks" }
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -867,7 +867,7 @@ if (!params.skip_merge_replicates) {
                 withName: '.*:MERGED_REPLICATE_CALL_ANNOTATE_PEAKS:PLOT_MACS2_QC' {
                     ext.args   = '-o ./ -p macs2_peak.mRp.clN'
                     publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
@@ -877,7 +877,7 @@ if (!params.skip_merge_replicates) {
                     ext.args   = '-o ./'
                     ext.prefix = 'macs2_annotatePeaks.mRp.clN'
                     publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/qc" },
+                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/qc" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
@@ -891,7 +891,7 @@ if (!params.skip_merge_replicates) {
             withName: '.*:MERGED_REPLICATE_CONSENSUS_PEAKS:MACS2_CONSENSUS' {
                 ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -901,7 +901,7 @@ if (!params.skip_merge_replicates) {
                 ext.args   = '-F SAF -O --fracOverlap 0.2'
                 ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -919,7 +919,7 @@ if (!params.skip_merge_replicates) {
                     ].join(' ').trim()
                     ext.prefix = { "${meta.id}.mRp.clN" }
                     publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus/deseq2" },
+                        path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus/deseq2" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
@@ -934,7 +934,7 @@ if (!params.skip_merge_replicates) {
                 ext.args   = '-gid'
                 ext.prefix = "consensus_peaks.mRp.clN"
                 publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}/consensus" },
+                    path: { "${params.outdir}/${params.aligner}/merged_replicate/macs2/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}/consensus" },
                     mode: params.publish_dir_mode,
                     saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                 ]
@@ -948,7 +948,7 @@ if (!params.skip_igv) {
         withName: 'IGV' {
             publishDir = [
                 [
-                    path: { "${params.outdir}/igv/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                    path: { "${params.outdir}/igv/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                     mode: params.publish_dir_mode,
                     pattern: '*.{txt,xml}'
                 ],
@@ -967,7 +967,7 @@ if (!params.skip_multiqc) {
         withName: 'MULTIQC' {
             ext.args   = params.multiqc_title ? "--title \"$params.multiqc_title\"" : ''
             publishDir = [
-                path: { "${params.outdir}/multiqc/${params.narrow_peak ? '/narrow_peak' : '/broad_peak'}" },
+                path: { "${params.outdir}/multiqc/${params.narrow_peak ? 'narrow_peak' : 'broad_peak'}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]


### PR DESCRIPTION
GCS does not allow double slashes (`//`) in paths by default. Other cloud storage platforms also do not have a well-defined behavior for them.

<!--
# nf-core/atacseq pull request

Many thanks for contributing to nf-core/atacseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/atacseq/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, also make a PR on the nf-core/atacseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Usage Documentation in `docs/usage.md` is updated.
- [X] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
