### PR TITLE
Modernize pipeline code for Nextflow strict (v2) syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [[#446]](https://github.com/nf-core/atacseq/pull/446) Modernize pipeline-owned Nextflow code for the strict (v2) syntax parser: lowercase `channel` factories, explicit closure parameters, and prefix unused parameters/variables with `_`. Lints clean under `NXF_SYNTAX_PARSER=v2` with no behaviour change.
+- [[#446]](https://github.com/nf-core/atacseq/pull/446) - Make pipeline code compliant with strict Nextflow v2 syntax parser, with no behaviour change.
 - [[#407]](https://github.com/nf-core/atacseq/pull/407) to add filtering reads according fragment size to help to focus on NFR, MNR, DNR, TNR
 - [[#164]](https://github.com/nf-core/atacseq/issues/164) and partly [[#91]](https://github.com/nf-core/atacseq/issues/91) with code from [[#301]](https://github.com/nf-core/atacseq/pull/301) to address shifting of reads as an option that is turned off by default.
 - [[#327](https://github.com/nf-core/atacseq/issues/327)] - Consistently support `.csi` indices as alternative to `.bai` to allow SAMTOOLS_INDEX to be used with the `-c` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- Modernize pipeline-owned Nextflow code for the strict (v2) syntax parser: lowercase `channel` factories, explicit closure parameters, and prefix unused parameters/variables with `_`. Lints clean under `NXF_SYNTAX_PARSER=v2` with no behaviour change.
+- [[#446]](https://github.com/nf-core/atacseq/pull/446) Modernize pipeline-owned Nextflow code for the strict (v2) syntax parser: lowercase `channel` factories, explicit closure parameters, and prefix unused parameters/variables with `_`. Lints clean under `NXF_SYNTAX_PARSER=v2` with no behaviour change.
 - [[#407]](https://github.com/nf-core/atacseq/pull/407) to add filtering reads according fragment size to help to focus on NFR, MNR, DNR, TNR
 - [[#164]](https://github.com/nf-core/atacseq/issues/164) and partly [[#91]](https://github.com/nf-core/atacseq/issues/91) with code from [[#301]](https://github.com/nf-core/atacseq/pull/301) to address shifting of reads as an option that is turned off by default.
 - [[#327](https://github.com/nf-core/atacseq/issues/327)] - Consistently support `.csi` indices as alternative to `.bai` to allow SAMTOOLS_INDEX to be used with the `-c` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- Modernize pipeline-owned Nextflow code for the strict (v2) syntax parser: lowercase `channel` factories, explicit closure parameters, and prefix unused parameters/variables with `_`. Lints clean under `NXF_SYNTAX_PARSER=v2` with no behaviour change.
 - [[#407]](https://github.com/nf-core/atacseq/pull/407) to add filtering reads according fragment size to help to focus on NFR, MNR, DNR, TNR
 - [[#164]](https://github.com/nf-core/atacseq/issues/164) and partly [[#91]](https://github.com/nf-core/atacseq/issues/91) with code from [[#301]](https://github.com/nf-core/atacseq/pull/301) to address shifting of reads as an option that is turned off by default.
 - [[#327](https://github.com/nf-core/atacseq/issues/327)] - Consistently support `.csi` indices as alternative to `.bai` to allow SAMTOOLS_INDEX to be used with the `-c` flag.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -388,7 +388,7 @@ process {
             path: { "${params.outdir}/${params.aligner}/merged_library" },
             mode: params.publish_dir_mode,
             pattern: '*.bam',
-            saveAs: { (meta.single_end || params.save_align_intermeds) ? "${it}" : null }
+            saveAs: { item -> (meta.single_end || params.save_align_intermeds) ? "${item}" : null }
         ]
     }
 

--- a/modules/local/macs3_consensus.nf
+++ b/modules/local/macs3_consensus.nf
@@ -30,12 +30,12 @@ process MACS3_CONSENSUS {
     def collapsecols = is_narrow_peak  ? (['collapse']*9).join(',') : (['collapse']*8).join(',')
     def expandparam  = is_narrow_peak  ? '--is_narrow_peak' : ''
     """
-    sort -T '.' -k1,1 -k2,2n ${peaks.collect{it.toString()}.sort().join(' ')} \\
+    sort -T '.' -k1,1 -k2,2n ${peaks.collect { item -> item.toString() }.sort().join(' ')} \\
         | mergeBed -c $mergecols -o $collapsecols > ${prefix}.txt
 
     macs3_merged_expand.py \\
         ${prefix}.txt \\
-        ${peaks.collect{it.toString()}.sort().join(',').replaceAll("_peaks.${peak_type}","")} \\
+        ${peaks.collect { item -> item.toString() }.sort().join(',').replaceAll("_peaks.${peak_type}","")} \\
         ${prefix}.boolean.txt \\
         $args \\
         $expandparam

--- a/subworkflows/local/align_star.nf
+++ b/subworkflows/local/align_star.nf
@@ -14,7 +14,7 @@ workflow ALIGN_STAR {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Map reads with STAR

--- a/subworkflows/local/bam_bedgraph_bigwig_bedtools_ucsc.nf
+++ b/subworkflows/local/bam_bedgraph_bigwig_bedtools_ucsc.nf
@@ -13,7 +13,7 @@ workflow BAM_BEDGRAPH_BIGWIG_BEDTOOLS_UCSC {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Create bedGraph coverage track

--- a/subworkflows/local/bam_filter_bamtools.nf
+++ b/subworkflows/local/bam_filter_bamtools.nf
@@ -16,7 +16,7 @@ workflow BAM_FILTER_BAMTOOLS {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Filter BAM file with BAMTools

--- a/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
+++ b/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
@@ -26,7 +26,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Call peaks with MACS3
@@ -44,7 +44,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
         .out
         .peak
         .filter {
-            meta, peaks ->
+            _meta, peaks ->
                 peaks.size() > 0
         }
         .set { ch_macs3_peaks }
@@ -53,7 +53,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
     ch_bam
         .join(ch_macs3_peaks, by: [0])
         .map {
-            meta, ip_bam, control_bam, peaks ->
+            meta, ip_bam, _control_bam, peaks ->
                 [ meta, ip_bam, peaks ]
         }
         .set { ch_bam_peaks }
@@ -70,7 +70,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
     ch_bam_peaks
         .join(FRIP_SCORE.out.txt, by: [0])
         .map {
-            meta, ip_bam, peaks, frip ->
+            meta, _ip_bam, peaks, frip ->
                 [ meta, peaks, frip ]
         }
         .set { ch_bam_peak_frip }
@@ -85,12 +85,12 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
     )
     ch_versions = ch_versions.mix(MULTIQC_CUSTOM_PEAKS.out.versions.first())
 
-    ch_homer_annotatepeaks          = Channel.empty()
-    ch_plot_macs3_qc_txt            = Channel.empty()
-    ch_plot_macs3_qc_pdf            = Channel.empty()
-    ch_plot_homer_annotatepeaks_txt = Channel.empty()
-    ch_plot_homer_annotatepeaks_pdf = Channel.empty()
-    ch_plot_homer_annotatepeaks_tsv = Channel.empty()
+    ch_homer_annotatepeaks          = channel.empty()
+    ch_plot_macs3_qc_txt            = channel.empty()
+    ch_plot_macs3_qc_pdf            = channel.empty()
+    ch_plot_homer_annotatepeaks_txt = channel.empty()
+    ch_plot_homer_annotatepeaks_pdf = channel.empty()
+    ch_plot_homer_annotatepeaks_tsv = channel.empty()
     if (!skip_peak_annotation) {
         //
         // Annotate peaks with HOMER
@@ -108,7 +108,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             // MACS3 QC plots with R
             //
             PLOT_MACS3_QC (
-                ch_macs3_peaks.collect{it[1]},
+                ch_macs3_peaks.collect { item -> item[1] },
                 is_narrow_peak
             )
             ch_plot_macs3_qc_txt = PLOT_MACS3_QC.out.txt
@@ -119,7 +119,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             // Peak annotation QC plots with R
             //
             PLOT_HOMER_ANNOTATEPEAKS (
-                HOMER_ANNOTATEPEAKS.out.txt.collect{it[1]},
+                HOMER_ANNOTATEPEAKS.out.txt.collect { item -> item[1] },
                 ch_peak_annotation_header_multiqc,
                 annotate_peaks_suffix
             )

--- a/subworkflows/local/bam_shift_reads.nf
+++ b/subworkflows/local/bam_shift_reads.nf
@@ -9,7 +9,7 @@ workflow BAM_SHIFT_READS {
     ch_fasta                     // channel: [ fasta ]
 
     main:
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Shift reads

--- a/subworkflows/local/bed_consensus_quantify_qc_bedtools_featurecounts_deseq2.nf
+++ b/subworkflows/local/bed_consensus_quantify_qc_bedtools_featurecounts_deseq2.nf
@@ -22,13 +22,13 @@ workflow BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     // Create channels: [ meta , [ peaks ] ]
     // where meta = [ id : consensus_peaks ]
     ch_peaks
-        .collect { it[1] }
-        .filter { it.size() > 1 }
+        .collect { item -> item[1] }
+        .filter { item -> item.size() > 1 }
         .map {
             peaks ->
                 [ [ id: 'consensus_peaks' ], peaks ]
@@ -47,7 +47,7 @@ workflow BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 {
     //
     // Annotate consensus peaks
     //
-    ch_homer_annotatepeaks = Channel.empty()
+    ch_homer_annotatepeaks = channel.empty()
     if (!skip_peak_annotation) {
         HOMER_ANNOTATEPEAKS (
             MACS3_CONSENSUS.out.bed,
@@ -61,12 +61,12 @@ workflow BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 {
     // Create channels: [ meta, [ bams ], saf ]
     ch_bams
         .join(ch_peaks)
-        .collect { it[1] }
-        .filter { it.size() > 1 }
-        .map { [ it ] }
+        .collect { item -> item[1] }
+        .filter { item -> item.size() > 1 }
+        .map { item -> [ item ] }
         .concat(MACS3_CONSENSUS.out.saf)
         .collect()
-        .filter { it.size() == 3 }
+        .filter { item -> item.size() == 3 }
         .map {
             bam, meta, saf ->
                 [ meta, bam , saf ]
@@ -84,15 +84,15 @@ workflow BED_CONSENSUS_QUANTIFY_QC_BEDTOOLS_FEATURECOUNTS_DESEQ2 {
     //
     // Generate QC plots with DESeq2
     //
-    ch_deseq2_qc_pdf           = Channel.empty()
-    ch_deseq2_qc_rdata         = Channel.empty()
-    ch_deseq2_qc_rds           = Channel.empty()
-    ch_deseq2_qc_pca_txt       = Channel.empty()
-    ch_deseq2_qc_pca_multiqc   = Channel.empty()
-    ch_deseq2_qc_dists_txt     = Channel.empty()
-    ch_deseq2_qc_dists_multiqc = Channel.empty()
-    ch_deseq2_qc_log           = Channel.empty()
-    ch_deseq2_qc_size_factors  = Channel.empty()
+    ch_deseq2_qc_pdf           = channel.empty()
+    ch_deseq2_qc_rdata         = channel.empty()
+    ch_deseq2_qc_rds           = channel.empty()
+    ch_deseq2_qc_pca_txt       = channel.empty()
+    ch_deseq2_qc_pca_multiqc   = channel.empty()
+    ch_deseq2_qc_dists_txt     = channel.empty()
+    ch_deseq2_qc_dists_multiqc = channel.empty()
+    ch_deseq2_qc_log           = channel.empty()
+    ch_deseq2_qc_size_factors  = channel.empty()
     if (!skip_deseq2_qc) {
         DESEQ2_QC (
             SUBREAD_FEATURECOUNTS.out.counts,

--- a/subworkflows/local/bigwig_plot_deeptools.nf
+++ b/subworkflows/local/bigwig_plot_deeptools.nf
@@ -16,7 +16,7 @@ workflow BIGWIG_PLOT_DEEPTOOLS {
 
     main:
 
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // deepTools matrix generation for plotting over full transcript length

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -8,18 +8,18 @@ workflow INPUT_CHECK {
     take:
     samplesheet  // file: /path/to/samplesheet.csv
     seq_center   // string: sequencing center for read group
-    with_control // boolean: samplesheet contains controls
+    _with_control // boolean: samplesheet contains controls
 
 
     main:
     SAMPLESHEET_CHECK ( samplesheet )
         .csv
         .splitCsv ( header:true, sep:',' )
-        .map { create_fastq_channel(it, seq_center) }
+        .map { item -> create_fastq_channel(item, seq_center) }
         .set { reads }
 
     emit:
-    reads                                     // channel: [ val(meta), [ reads ] ]
+    reads = reads // channel: [ val(meta), [ reads ] ]
     versions = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }
 

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -50,17 +50,17 @@ workflow PREPARE_GENOME {
     read_length        // integer: read length
 
     main:
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     //
     // Uncompress genome fasta file if required
     //
-    ch_fasta = Channel.empty()
+    ch_fasta = channel.empty()
     if (fasta.endsWith('.gz')) {
         ch_fasta    = GUNZIP_FASTA ( [ [:], fasta ] ).gunzip.map { tuple -> tuple[1] }
         ch_versions = ch_versions.mix(GUNZIP_FASTA.out.versions)
     } else {
-        ch_fasta = Channel.value(file(fasta, checkIfExists: true))
+        ch_fasta = channel.value(file(fasta, checkIfExists: true))
     }
 
     //
@@ -71,14 +71,14 @@ workflow PREPARE_GENOME {
             ch_gtf      = GUNZIP_GTF ( [ [:], gtf ] ).gunzip.map { tuple -> tuple[1] }
             ch_versions = ch_versions.mix(GUNZIP_GTF.out.versions)
         } else {
-            ch_gtf = Channel.value(file(gtf, checkIfExists: true))
+            ch_gtf = channel.value(file(gtf, checkIfExists: true))
         }
     } else if (gff) {
         if (gff.endsWith('.gz')) {
             ch_gff      = GUNZIP_GFF ( [ [:], gff ] ).gunzip.map { tuple -> tuple[1] }
             ch_versions = ch_versions.mix(GUNZIP_GFF.out.versions)
         } else {
-            ch_gff = Channel.value(file(gff, checkIfExists: true))
+            ch_gff = channel.value(file(gff, checkIfExists: true))
         }
         ch_gtf      = GFFREAD ( ch_gff ).gtf
         ch_versions = ch_versions.mix(GFFREAD.out.versions)
@@ -87,13 +87,13 @@ workflow PREPARE_GENOME {
     //
     // Uncompress blacklist file if required
     //
-    ch_blacklist = Channel.empty()
+    ch_blacklist = channel.empty()
     if (blacklist) {
         if (blacklist.endsWith('.gz')) {
             ch_blacklist = GUNZIP_BLACKLIST ( [ [:], blacklist ] ).gunzip.map { tuple -> tuple[1] }
             ch_versions  = ch_versions.mix(GUNZIP_BLACKLIST.out.versions)
         } else {
-            ch_blacklist = Channel.value(file(blacklist, checkIfExists: true))
+            ch_blacklist = channel.value(file(blacklist, checkIfExists: true))
         }
     }
 
@@ -118,7 +118,7 @@ workflow PREPARE_GENOME {
             ch_gene_bed = GUNZIP_GENE_BED ( [ [:], params.gene_bed ] ).gunzip.map { tuple -> tuple[1] }
             ch_versions = ch_versions.mix(GUNZIP_GENE_BED.out.versions)
         } else {
-            ch_gene_bed = Channel.value(file(gene_bed, checkIfExists: true))
+            ch_gene_bed = channel.value(file(gene_bed, checkIfExists: true))
         }
     }
 
@@ -130,7 +130,7 @@ workflow PREPARE_GENOME {
             ch_tss_bed = GUNZIP_TSS_BED ( [ [:], tss_bed ] ).gunzip.map { tuple -> tuple[1] }
             ch_versions = ch_versions.mix(GUNZIP_TSS_BED.out.versions)
         } else {
-            ch_tss_bed = Channel.value(file(tss_bed, checkIfExists: true))
+            ch_tss_bed = channel.value(file(tss_bed, checkIfExists: true))
         }
     }
 
@@ -145,7 +145,7 @@ workflow PREPARE_GENOME {
     //
     // Create autosomal chromosome list for ataqv
     //
-    ch_genome_autosomes = Channel.empty()
+    ch_genome_autosomes = channel.empty()
     GET_AUTOSOMES (
         ch_fai
     )
@@ -156,7 +156,7 @@ workflow PREPARE_GENOME {
     //
     // Prepare genome intervals for filtering by removing regions in blacklist file
     //
-    ch_genome_filtered_bed = Channel.empty()
+    ch_genome_filtered_bed = channel.empty()
     GENOME_BLACKLIST_REGIONS (
         ch_chrom_sizes,
         ch_blacklist.ifEmpty([]),
@@ -169,7 +169,7 @@ workflow PREPARE_GENOME {
     //
     // Uncompress BWA index or generate from scratch if required
     //
-    ch_bwa_index = Channel.empty()
+    ch_bwa_index = channel.empty()
     if (prepare_tool_index == 'bwa') {
         if (bwa_index) {
             if (bwa_index.endsWith('.tar.gz')) {
@@ -186,7 +186,7 @@ workflow PREPARE_GENOME {
     //
     // Uncompress Bowtie2 index or generate from scratch if required
     //
-    ch_bowtie2_index = Channel.empty()
+    ch_bowtie2_index = channel.empty()
     if (prepare_tool_index == 'bowtie2') {
         if (bowtie2_index) {
             if (bowtie2_index.endsWith('.tar.gz')) {
@@ -204,7 +204,7 @@ workflow PREPARE_GENOME {
     //
     // Uncompress CHROMAP index or generate from scratch if required
     //
-    ch_chromap_index = Channel.empty()
+    ch_chromap_index = channel.empty()
     if (prepare_tool_index == 'chromap') {
         if (chromap_index) {
             if (chromap_index.endsWith('.tar.gz')) {
@@ -222,14 +222,14 @@ workflow PREPARE_GENOME {
     //
     // Uncompress STAR index or generate from scratch if required
     //
-    ch_star_index = Channel.empty()
+    ch_star_index = channel.empty()
     if (prepare_tool_index == 'star') {
         if (star_index) {
             if (star_index.endsWith('.tar.gz')) {
                 ch_star_index = UNTAR_STAR_INDEX ( [ [:], star_index ] ).untar.map{ tuple -> tuple[1] }
                 ch_versions   = ch_versions.mix(UNTAR_STAR_INDEX.out.versions)
             } else {
-                ch_star_index = Channel.value(file(star_index, checkIfExists: true))
+                ch_star_index = channel.value(file(star_index, checkIfExists: true))
             }
         } else {
             ch_star_index = STAR_GENOMEGENERATE ( ch_fasta, ch_gtf ).index

--- a/subworkflows/local/utils_nfcore_atacseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_atacseq_pipeline/main.nf
@@ -31,14 +31,14 @@ workflow PIPELINE_INITIALISATION {
     monochrome_logs   // boolean: Do not use coloured log outputs
     nextflow_cli_args //   array: List of positional nextflow CLI args
     outdir            //  string: The output directory where the results will be saved
-    input             //  string: Path to input samplesheet
+    _input             //  string: Path to input samplesheet
     help              // boolean: Display help message and exit
     help_full         // boolean: Show the full help message
     show_hidden       // boolean: Show hidden parameters in the help message
 
     main:
 
-    ch_versions = channel.empty()
+    _ch_versions = channel.empty()
 
     //
     // Print version and exit if required and dump pipeline parameters to JSON file

--- a/subworkflows/local/utils_nfcore_atacseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_atacseq_pipeline/main.nf
@@ -38,8 +38,6 @@ workflow PIPELINE_INITIALISATION {
 
     main:
 
-    _ch_versions = channel.empty()
-
     //
     // Print version and exit if required and dump pipeline parameters to JSON file
     //

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -221,7 +221,6 @@ workflow ATACSEQ {
             []
         )
         ch_genome_bam        = FASTQ_ALIGN_CHROMAP.out.bam
-        _ch_genome_bam_index  = FASTQ_ALIGN_CHROMAP.out.bai
         ch_samtools_stats    = FASTQ_ALIGN_CHROMAP.out.stats
         ch_samtools_flagstat = FASTQ_ALIGN_CHROMAP.out.flagstat
         ch_samtools_idxstats = FASTQ_ALIGN_CHROMAP.out.idxstats

--- a/workflows/atacseq.nf
+++ b/workflows/atacseq.nf
@@ -125,7 +125,7 @@ workflow ATACSEQ {
         params.with_control
     )
     ch_versions = ch_versions.mix(INPUT_CHECK.out.versions)
-    // TODO: OPTIONAL, you can use nf-validation plugin to create an input channel from the samplesheet with Channel.fromSamplesheet("input")
+    // TODO: OPTIONAL, you can use nf-validation plugin to create an input channel from the samplesheet with channel.fromSamplesheet("input")
     // See the documentation https://nextflow-io.github.io/nf-validation/samplesheets/fromSamplesheet/
     // ! There is currently no tooling to help you write a sample sheet schema
 
@@ -136,11 +136,10 @@ workflow ATACSEQ {
         INPUT_CHECK
             .out
             .reads
-            .filter { meta, reads -> meta.single_end }
+            .filter { meta, _reads -> meta.single_end }
             .collect()
-            .map {
-                it ->
-                    def count = it.size()
+            .map { item ->
+                    def count = item.size()
                     if (count > 0) {
                         exit 1, 'The parameter --shift_reads can only be applied if all samples are paired-end.'
                     }
@@ -163,18 +162,18 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Alignment with BWA & BAM QC
     //
-    ch_genome_bam        = Channel.empty()
-    ch_samtools_stats    = Channel.empty()
-    ch_samtools_flagstat = Channel.empty()
-    ch_samtools_idxstats = Channel.empty()
+    ch_genome_bam        = channel.empty()
+    ch_samtools_stats    = channel.empty()
+    ch_samtools_flagstat = channel.empty()
+    ch_samtools_idxstats = channel.empty()
     if (params.aligner == 'bwa') {
         FASTQ_ALIGN_BWA (
             FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.reads,
             ch_bwa_index,
             false,
             ch_fasta
-                .map {
-                        [ [:], it ]
+                .map { item ->
+                        [ [:], item ]
                 }
         )
         ch_genome_bam        = FASTQ_ALIGN_BWA.out.bam
@@ -194,8 +193,8 @@ workflow ATACSEQ {
             params.save_unaligned,
             false,
             ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 }
         )
         ch_genome_bam        = FASTQ_ALIGN_BOWTIE2.out.bam
@@ -213,8 +212,8 @@ workflow ATACSEQ {
             FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.reads,
             ch_chromap_index,
             ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 },
             [],
             [],
@@ -222,7 +221,7 @@ workflow ATACSEQ {
             []
         )
         ch_genome_bam        = FASTQ_ALIGN_CHROMAP.out.bam
-        ch_genome_bam_index  = FASTQ_ALIGN_CHROMAP.out.bai
+        _ch_genome_bam_index  = FASTQ_ALIGN_CHROMAP.out.bai
         ch_samtools_stats    = FASTQ_ALIGN_CHROMAP.out.stats
         ch_samtools_flagstat = FASTQ_ALIGN_CHROMAP.out.flagstat
         ch_samtools_idxstats = FASTQ_ALIGN_CHROMAP.out.idxstats
@@ -232,14 +231,14 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Alignment with STAR & BAM QC
     //
-    ch_star_multiqc = Channel.empty()
+    ch_star_multiqc = channel.empty()
     if (params.aligner == 'star') {
         ALIGN_STAR (
             FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.reads,
             ch_star_index,
             ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 },
             params.seq_center ?: ''
         )
@@ -281,12 +280,12 @@ workflow ATACSEQ {
     MERGED_LIBRARY_MARKDUPLICATES_PICARD (
         PICARD_MERGESAMFILES_LIBRARY.out.bam,
         ch_fasta
-            .map {
-                [ [:], it ]
+            .map { item ->
+                [ [:], item ]
             },
         ch_fai
-            .map {
-                [ [:], it ]
+            .map { item ->
+                [ [:], item ]
             }
     )
     ch_versions = ch_versions.mix(MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.versions)
@@ -308,8 +307,8 @@ workflow ATACSEQ {
             },
         ch_filtered_bed.first(),
         ch_fasta
-            .map {
-                [ [:], it ]
+            .map { item ->
+                [ [:], item ]
             },
         ch_bamtools_filter_se_config,
         ch_bamtools_filter_pe_config
@@ -319,7 +318,7 @@ workflow ATACSEQ {
     //
     // MODULE: Preseq coverage analysis
     //
-    ch_preseq_multiqc = Channel.empty()
+    ch_preseq_multiqc = channel.empty()
     if (!params.skip_preseq) {
         MERGED_LIBRARY_PRESEQ_LCEXTRAP (
             MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.bam
@@ -331,22 +330,22 @@ workflow ATACSEQ {
     //
     // MODULE: Picard post alignment QC
     //
-    ch_picardcollectmultiplemetrics_multiqc = Channel.empty()
+    ch_picardcollectmultiplemetrics_multiqc = channel.empty()
     if (!params.skip_picard_metrics) {
         MERGED_LIBRARY_PICARD_COLLECTMULTIPLEMETRICS (
             MERGED_LIBRARY_FILTER_BAM
                 .out
                 .bam
-                .map {
-                    [ it[0], it[1], [] ]
+                .map { item ->
+                    [ item[0], item[1], [] ]
                 },
             ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 },
             ch_fai
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 }
         )
         ch_picardcollectmultiplemetrics_multiqc = MERGED_LIBRARY_PICARD_COLLECTMULTIPLEMETRICS.out.metrics
@@ -365,8 +364,8 @@ workflow ATACSEQ {
         MERGED_LIBRARY_BAM_SHIFT_READS (
             ch_merged_library_filter_bam.join(ch_merged_library_filter_bai, by: [0]),
             ch_fasta
-            .map {
-                [ [:], it ]
+            .map { item ->
+                [ [:], item ]
             }
         )
         ch_versions = ch_versions.mix(MERGED_LIBRARY_BAM_SHIFT_READS.out.versions)
@@ -392,7 +391,7 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Plot coverage across annotation with deepTools
     //
-    ch_deeptoolsplotprofile_multiqc = Channel.empty()
+    ch_deeptoolsplotprofile_multiqc = channel.empty()
     if (!params.skip_plot_profile) {
         MERGED_LIBRARY_BIGWIG_PLOT_DEEPTOOLS (
             MERGED_LIBRARY_BAM_TO_BIGWIG.out.bigwig,
@@ -431,14 +430,14 @@ workflow ATACSEQ {
                     meta.control ? [ meta.control, meta, [ bam ], [ bai ] ] : null
             }
             .combine(ch_control_bam_bai, by: 0)
-            .map { it -> [ it[1] , it[2] + it[4], it[3] + it[5] ] }
+            .map { item -> [ item[1] , item[2] + item[4], item[3] + item[5] ] }
             .set { ch_bam_bai }
     }
 
     //
     // MODULE: deepTools plotFingerprint QC
     //
-    ch_deeptoolsplotfingerprint_multiqc = Channel.empty()
+    ch_deeptoolsplotfingerprint_multiqc = channel.empty()
     if (!params.skip_plot_fingerprint) {
         MERGED_LIBRARY_DEEPTOOLS_PLOTFINGERPRINT (
             ch_bam_bai
@@ -451,14 +450,14 @@ workflow ATACSEQ {
     if (params.with_control) {
         ch_bam_bai
             .map {
-                meta, bams, bais ->
+                meta, bams, _bais ->
                     [ meta , bams[0], bams[1] ]
             }
             .set { ch_bam_library }
     } else {
         ch_bam_bai
             .map {
-                meta, bam, bai ->
+                meta, bam, _bai ->
                     [ meta , bam, [] ]
             }
             .set { ch_bam_library }
@@ -485,10 +484,10 @@ workflow ATACSEQ {
     //
     // SUBWORKFLOW: Consensus peaks analysis
     //
-    ch_macs3_consensus_library_bed       = Channel.empty()
-    ch_featurecounts_library_multiqc     = Channel.empty()
-    ch_deseq2_pca_library_multiqc        = Channel.empty()
-    ch_deseq2_clustering_library_multiqc = Channel.empty()
+    ch_macs3_consensus_library_bed       = channel.empty()
+    ch_featurecounts_library_multiqc     = channel.empty()
+    ch_deseq2_pca_library_multiqc        = channel.empty()
+    ch_deseq2_clustering_library_multiqc = channel.empty()
     if (!params.skip_consensus_peaks) {
         MERGED_LIBRARY_CONSENSUS_PEAKS (
             MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.peaks,
@@ -540,7 +539,7 @@ workflow ATACSEQ {
         ch_versions = ch_versions.mix(MERGED_LIBRARY_ATAQV_ATAQV.out.versions.first())
 
         MERGED_LIBRARY_ATAQV_MKARV (
-            MERGED_LIBRARY_ATAQV_ATAQV.out.json.collect{it[1]}
+            MERGED_LIBRARY_ATAQV_ATAQV.out.json.collect { item -> item[1] }
         )
         ch_versions = ch_versions.mix(MERGED_LIBRARY_ATAQV_MKARV.out.versions)
     }
@@ -548,19 +547,19 @@ workflow ATACSEQ {
     //
     // Merged replicate analysis
     //
-    ch_markduplicates_replicate_stats                   = Channel.empty()
-    ch_markduplicates_replicate_flagstat                = Channel.empty()
-    ch_markduplicates_replicate_idxstats                = Channel.empty()
-    ch_markduplicates_replicate_metrics                 = Channel.empty()
-    ch_ucsc_bedgraphtobigwig_replicate_bigwig           = Channel.empty()
-    ch_macs3_replicate_peaks                            = Channel.empty()
-    ch_macs3_frip_replicate_multiqc                     = Channel.empty()
-    ch_macs3_peak_count_replicate_multiqc               = Channel.empty()
-    ch_macs3_plot_homer_annotatepeaks_replicate_multiqc = Channel.empty()
-    ch_macs3_consensus_replicate_bed                    = Channel.empty()
-    ch_featurecounts_replicate_multiqc                  = Channel.empty()
-    ch_deseq2_pca_replicate_multiqc                     = Channel.empty()
-    ch_deseq2_clustering_replicate_multiqc              = Channel.empty()
+    ch_markduplicates_replicate_stats                   = channel.empty()
+    ch_markduplicates_replicate_flagstat                = channel.empty()
+    ch_markduplicates_replicate_idxstats                = channel.empty()
+    ch_markduplicates_replicate_metrics                 = channel.empty()
+    ch_ucsc_bedgraphtobigwig_replicate_bigwig           = channel.empty()
+    ch_macs3_replicate_peaks                            = channel.empty()
+    ch_macs3_frip_replicate_multiqc                     = channel.empty()
+    ch_macs3_peak_count_replicate_multiqc               = channel.empty()
+    ch_macs3_plot_homer_annotatepeaks_replicate_multiqc = channel.empty()
+    ch_macs3_consensus_replicate_bed                    = channel.empty()
+    ch_featurecounts_replicate_multiqc                  = channel.empty()
+    ch_deseq2_pca_replicate_multiqc                     = channel.empty()
+    ch_deseq2_clustering_replicate_multiqc              = channel.empty()
     if (!params.skip_merge_replicates) {
 
         // Check if we have multiple replicates
@@ -576,7 +575,7 @@ workflow ATACSEQ {
             }
             .groupTuple()
             .map {
-                id, metas, bams ->
+                _id, metas, bams ->
                     if (bams.size() > 1) {
                         return [ metas[0], bams ]
                     }
@@ -597,12 +596,12 @@ workflow ATACSEQ {
         MERGED_REPLICATE_MARKDUPLICATES_PICARD (
             PICARD_MERGESAMFILES_REPLICATE.out.bam,
             ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 },
             ch_fai
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 }
         )
         ch_markduplicates_replicate_stats    = MERGED_REPLICATE_MARKDUPLICATES_PICARD.out.stats
@@ -624,8 +623,8 @@ workflow ATACSEQ {
             MERGED_REPLICATE_BAM_SHIFT_READS (
                 ch_merged_replicate_markduplicate_bam.join(ch_merged_replicate_markduplicate_bai, by: [0]),
                 ch_fasta
-                .map {
-                    [ [:], it ]
+                .map { item ->
+                    [ [:], item ]
                 }
             )
             ch_versions = ch_versions.mix(MERGED_REPLICATE_BAM_SHIFT_READS.out.versions)
@@ -661,7 +660,7 @@ workflow ATACSEQ {
                         meta.control ? [ meta.control, meta, bam ] : null
                 }
                 .combine( ch_bam_merged_control, by: 0)
-                .map { it -> [ it[1] , it[2], it[3] ] }
+                .map { item -> [ item[1] , item[2], item[3] ] }
                 .set { ch_bam_replicate }
         } else {
             ch_merged_replicate_markduplicate_bam
@@ -724,12 +723,12 @@ workflow ATACSEQ {
         IGV (
             ch_fasta,
             ch_fai,
-            MERGED_LIBRARY_BAM_TO_BIGWIG.out.bigwig.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.peaks.collect{it[1]}.ifEmpty([]),
-            ch_macs3_consensus_library_bed.collect{it[1]}.ifEmpty([]),
-            ch_ucsc_bedgraphtobigwig_replicate_bigwig.collect{it[1]}.ifEmpty([]),
-            ch_macs3_replicate_peaks.collect{it[1]}.ifEmpty([]),
-            ch_macs3_consensus_replicate_bed.collect{it[1]}.ifEmpty([]),
+            MERGED_LIBRARY_BAM_TO_BIGWIG.out.bigwig.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.peaks.collect { item -> item[1] }.ifEmpty([]),
+            ch_macs3_consensus_library_bed.collect { item -> item[1] }.ifEmpty([]),
+            ch_ucsc_bedgraphtobigwig_replicate_bigwig.collect { item -> item[1] }.ifEmpty([]),
+            ch_macs3_replicate_peaks.collect { item -> item[1] }.ifEmpty([]),
+            ch_macs3_consensus_replicate_bed.collect { item -> item[1] }.ifEmpty([]),
             "${params.aligner}/merged_library/bigwig",
             { ["${params.aligner}/merged_library/macs3",
                 params.narrow_peak? '/narrow_peak' : '/broad_peak'
@@ -785,13 +784,13 @@ workflow ATACSEQ {
     def ch_multiqc_report = channel.empty()
 
     if (!params.skip_multiqc) {
-        def ch_multiqc_config                     = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
-        def ch_multiqc_custom_config              = multiqc_config ? Channel.fromPath(multiqc_config) : Channel.empty()
-        def ch_multiqc_logo                       = multiqc_logo   ? Channel.fromPath(multiqc_logo)   : Channel.empty()
+        def ch_multiqc_config                     = channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+        def ch_multiqc_custom_config              = multiqc_config ? channel.fromPath(multiqc_config) : channel.empty()
+        def ch_multiqc_logo                       = multiqc_logo   ? channel.fromPath(multiqc_logo)   : channel.empty()
         def ch_summary_params                     = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
-        def ch_workflow_summary                   = Channel.value(paramsSummaryMultiqc(ch_summary_params))
+        def ch_workflow_summary                   = channel.value(paramsSummaryMultiqc(ch_summary_params))
         def ch_multiqc_custom_methods_description = multiqc_methods_description ? file(multiqc_methods_description, checkIfExists: true) : file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
-        def ch_methods_description                = Channel.value(methodsDescriptionText(ch_multiqc_custom_methods_description))
+        def ch_methods_description                = channel.value(methodsDescriptionText(ch_multiqc_custom_methods_description))
         ch_multiqc_files                          = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
         ch_multiqc_files                          = ch_multiqc_files.mix(ch_collated_versions)
         ch_multiqc_files                          = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: false))
@@ -802,43 +801,43 @@ workflow ATACSEQ {
             ch_multiqc_custom_config.toList(),
             ch_multiqc_logo.toList(),
 
-            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.fastqc_zip.collect{it[1]}.ifEmpty([]),
-            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.trim_zip.collect{it[1]}.ifEmpty([]),
-            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.trim_log.collect{it[1]}.ifEmpty([]),
+            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.fastqc_zip.collect { item -> item[1] }.ifEmpty([]),
+            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.trim_zip.collect { item -> item[1] }.ifEmpty([]),
+            FASTQ_FASTQC_UMITOOLS_TRIMGALORE.out.trim_log.collect { item -> item[1] }.ifEmpty([]),
 
-            ch_samtools_stats.collect{it[1]}.ifEmpty([]),
-            ch_samtools_flagstat.collect{it[1]}.ifEmpty([]),
-            ch_samtools_idxstats.collect{it[1]}.ifEmpty([]),
+            ch_samtools_stats.collect { item -> item[1] }.ifEmpty([]),
+            ch_samtools_flagstat.collect { item -> item[1] }.ifEmpty([]),
+            ch_samtools_idxstats.collect { item -> item[1] }.ifEmpty([]),
 
-            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.stats.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.flagstat.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.idxstats.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.metrics.collect{it[1]}.ifEmpty([]),
+            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.stats.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.flagstat.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.idxstats.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_MARKDUPLICATES_PICARD.out.metrics.collect { item -> item[1] }.ifEmpty([]),
 
-            MERGED_LIBRARY_FILTER_BAM.out.stats.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_FILTER_BAM.out.flagstat.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_FILTER_BAM.out.idxstats.collect{it[1]}.ifEmpty([]),
-            ch_picardcollectmultiplemetrics_multiqc.collect{it[1]}.ifEmpty([]),
+            MERGED_LIBRARY_FILTER_BAM.out.stats.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_FILTER_BAM.out.flagstat.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_FILTER_BAM.out.idxstats.collect { item -> item[1] }.ifEmpty([]),
+            ch_picardcollectmultiplemetrics_multiqc.collect { item -> item[1] }.ifEmpty([]),
 
-            ch_preseq_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_preseq_multiqc.collect { item -> item[1] }.ifEmpty([]),
 
-            ch_deeptoolsplotprofile_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_deeptoolsplotfingerprint_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_deeptoolsplotprofile_multiqc.collect { item -> item[1] }.ifEmpty([]),
+            ch_deeptoolsplotfingerprint_multiqc.collect { item -> item[1] }.ifEmpty([]),
 
-            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.frip_multiqc.collect{it[1]}.ifEmpty([]),
-            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.peak_count_multiqc.collect{it[1]}.ifEmpty([]),
+            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.frip_multiqc.collect { item -> item[1] }.ifEmpty([]),
+            MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.peak_count_multiqc.collect { item -> item[1] }.ifEmpty([]),
             MERGED_LIBRARY_CALL_ANNOTATE_PEAKS.out.plot_homer_annotatepeaks_tsv.collect().ifEmpty([]),
-            ch_featurecounts_library_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_featurecounts_library_multiqc.collect { item -> item[1] }.ifEmpty([]),
 
-            ch_markduplicates_replicate_stats.collect{it[1]}.ifEmpty([]),
-            ch_markduplicates_replicate_flagstat.collect{it[1]}.ifEmpty([]),
-            ch_markduplicates_replicate_idxstats.collect{it[1]}.ifEmpty([]),
-            ch_markduplicates_replicate_metrics.collect{it[1]}.ifEmpty([]),
+            ch_markduplicates_replicate_stats.collect { item -> item[1] }.ifEmpty([]),
+            ch_markduplicates_replicate_flagstat.collect { item -> item[1] }.ifEmpty([]),
+            ch_markduplicates_replicate_idxstats.collect { item -> item[1] }.ifEmpty([]),
+            ch_markduplicates_replicate_metrics.collect { item -> item[1] }.ifEmpty([]),
 
-            ch_macs3_frip_replicate_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_macs3_peak_count_replicate_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_macs3_frip_replicate_multiqc.collect { item -> item[1] }.ifEmpty([]),
+            ch_macs3_peak_count_replicate_multiqc.collect { item -> item[1] }.ifEmpty([]),
             ch_macs3_plot_homer_annotatepeaks_replicate_multiqc.collect().ifEmpty([]),
-            ch_featurecounts_replicate_multiqc.collect{it[1]}.ifEmpty([]),
+            ch_featurecounts_replicate_multiqc.collect { item -> item[1] }.ifEmpty([]),
 
             ch_deseq2_pca_library_multiqc.collect().ifEmpty([]),
             ch_deseq2_clustering_library_multiqc.collect().ifEmpty([]),


### PR DESCRIPTION
Make the pipeline-owned Nextflow code lint clean under strict syntax. 

Changes: 
- lowercase `channel` factories (Channel.* -> channel.*)
- declare explicit closure parameters instead of implicit `it`
- prefix unused parameters/variables with `_`
- normalize explicit-parameter closure formatting (spacing around `->` and braces; consistent `item` parameter naming)

No behaviour change. Scope is limited to pipeline-owned files; strict-syntax fixes for vendored nf-core/ modules and subworkflows belong upstream in nf-core/modules and should arrive via `nf-core modules/subworkflows update`.

## PR checklist

- [X] This comment contains a description of changes.
- [ ] Add tests — N/A; no behaviour change, no new code paths. MultiQC run on test samples preserved behavior.
- [ ] New tool conventions — N/A; no new tool.
- [ ] test-datasets PR — N/A; no input/data changes.
- [x] Code lints — nextflow lint is clean. 
- [x] Test suite passes — full-size test_full ran clean (267 tasks, 0 failed) on a tree identical to this commit; -profile test,docker re-confirmed by CI.
- [ ] docs/usage.md — no update needed (no param/usage change).
- [ ] docs/output.md — no update needed (no output change).
- [x] CHANGELOG.md — updated (your commit adds the entry).
- [ ] README.md — no update needed (no new tools/citations/authors).
