### PR TITLE
Sort peak QC plot inputs deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#438](https://github.com/nf-core/atacseq/issues/438)] - Add `checkIfExists` to file inputs in `PREPARE_GENOME` and prevent S3 access errors during index validation.
 - [[PR #443](https://github.com/nf-core/atacseq/pull/443)] - Updated pipeline template to [nf-core/tools 4.0.2](https://github.com/nf-core/tools/releases/tag/4.0.2)
 - [[PR #453](https://github.com/nf-core/atacseq/pull/453)] - Updated pipeline template to [nf-core/tools 4.0.3](https://github.com/nf-core/tools/releases/tag/4.0.3)
+- [[PR #454](https://github.com/nf-core/atacseq/pull/454)] - Sort the peak QC plot inputs by file name so that `PLOT_MACS3_QC` and `PLOT_HOMER_ANNOTATEPEAKS` outputs no longer depend on task completion order.
 
 ### Parameters
 

--- a/modules/local/plot_homer_annotatepeaks.nf
+++ b/modules/local/plot_homer_annotatepeaks.nf
@@ -23,10 +23,12 @@ process PLOT_HOMER_ANNOTATEPEAKS {
     script: // This script is bundled with the pipeline, in nf-core/chipseq/bin/
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "annotatepeaks"
+    // Files arrive in task-completion order; sort so sample order in the outputs is reproducible.
+    def anno_list = annos.toSorted { anno -> anno.name }.join(',')
     """
     plot_homer_annotatepeaks.r \\
-        -i ${annos.join(',')} \\
-        -s ${annos.join(',').replaceAll("${suffix}","")} \\
+        -i ${anno_list} \\
+        -s ${anno_list.replaceAll("${suffix}","")} \\
         -p $prefix \\
         $args
 

--- a/modules/local/plot_macs3_qc.nf
+++ b/modules/local/plot_macs3_qc.nf
@@ -21,10 +21,12 @@ process PLOT_MACS3_QC {
     script: // This script is bundled with the pipeline, in nf-core/atacseq/bin/
     def args      = task.ext.args ?: ''
     def peak_type = is_narrow_peak ? 'narrowPeak' : 'broadPeak'
+    // Files arrive in task-completion order; sort so sample order in the outputs is reproducible.
+    def peak_list = peaks.toSorted { peak -> peak.name }.join(',')
     """
     plot_macs3_qc.r \\
-        -i ${peaks.join(',')} \\
-        -s ${peaks.join(',').replaceAll("_peaks.${peak_type}","")} \\
+        -i ${peak_list} \\
+        -s ${peak_list.replaceAll("_peaks.${peak_type}","")} \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
+++ b/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
@@ -107,12 +107,8 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             //
             // MACS3 QC plots with R
             //
-            // Sort by file name: the R scripts derive sample ids from the order of
-            // the file list, and `collect` emits in task-completion order.
             PLOT_MACS3_QC (
-                ch_macs3_peaks
-                    .map { item -> item[1] }
-                    .toSortedList { a, b -> a.name <=> b.name },
+                ch_macs3_peaks.collect { item -> item[1] },
                 is_narrow_peak
             )
             ch_plot_macs3_qc_txt = PLOT_MACS3_QC.out.txt
@@ -123,9 +119,7 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             // Peak annotation QC plots with R
             //
             PLOT_HOMER_ANNOTATEPEAKS (
-                HOMER_ANNOTATEPEAKS.out.txt
-                    .map { item -> item[1] }
-                    .toSortedList { a, b -> a.name <=> b.name },
+                HOMER_ANNOTATEPEAKS.out.txt.collect { item -> item[1] },
                 ch_peak_annotation_header_multiqc,
                 annotate_peaks_suffix
             )

--- a/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
+++ b/subworkflows/local/bam_peaks_call_qc_annotate_macs3_homer.nf
@@ -107,8 +107,12 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             //
             // MACS3 QC plots with R
             //
+            // Sort by file name: the R scripts derive sample ids from the order of
+            // the file list, and `collect` emits in task-completion order.
             PLOT_MACS3_QC (
-                ch_macs3_peaks.collect { item -> item[1] },
+                ch_macs3_peaks
+                    .map { item -> item[1] }
+                    .toSortedList { a, b -> a.name <=> b.name },
                 is_narrow_peak
             )
             ch_plot_macs3_qc_txt = PLOT_MACS3_QC.out.txt
@@ -119,7 +123,9 @@ workflow BAM_PEAKS_CALL_QC_ANNOTATE_MACS3_HOMER {
             // Peak annotation QC plots with R
             //
             PLOT_HOMER_ANNOTATEPEAKS (
-                HOMER_ANNOTATEPEAKS.out.txt.collect { item -> item[1] },
+                HOMER_ANNOTATEPEAKS.out.txt
+                    .map { item -> item[1] }
+                    .toSortedList { a, b -> a.name <=> b.name },
                 ch_peak_annotation_header_multiqc,
                 annotate_peaks_suffix
             )


### PR DESCRIPTION
Fixes an intermittent nf-test snapshot failure in `tests/skip_trimming.nf.test`.

## The flake

The same commit produced opposite results on the same Nextflow version (`26.07.0-edge`), with only `CHANGELOG.md` differing between the two pipeline states:

| Run | Result |
| --- | --- |
| [30818548816](https://github.com/nf-core/atacseq/actions/runs/30818548816) (Aug 3) | passed |
| [32331137515](https://github.com/nf-core/atacseq/actions/runs/32331137515) attempt 1 (Aug 20) | ❌ `docker \| latest-everything \| 2/7` |
| [32331137515](https://github.com/nf-core/atacseq/actions/runs/32331137515) attempt 2 (Aug 21) | passed |

Three md5s differ when it fails, all from the same source: `macs3_annotatePeaks.mLb.clN.summary.txt`, `macs3_annotatePeaks.mLb.clN.summary_mqc.tsv`, and the `multiqc_mlib_peak_annotation-plot.txt` derived from them.

## Cause

`collect` emits in task-completion order, and `PLOT_MACS3_QC` / `PLOT_HOMER_ANNOTATEPEAKS` derive their sample ids from the order of the file list via `-i ${annos.join(',')}` / `-s ...`.

In `bin/plot_homer_annotatepeaks.r` the summary *rows* are already deterministic — lines 99-101 sort the factor levels. The *columns* are not: `summary.dat <- dcast(plot.feature.dat, variable ~ feature)` takes its column order from the `feature` factor levels, which accumulate by first appearance across the input files. Samples with differing feature sets therefore produce different column orders depending on which file was read first, which is why this only trips occasionally.

## Fix

Sort the staged file list by name inside the two process scripts.

## Notes

- Snapshots may need regenerating if the sorted order differs from the order baked into the current values.
- `subworkflows/local/bed_consensus_quantify_qc_bedtools_featurecounts_deseq2.nf` lines 30 and 64 have the same unsorted-`collect` pattern feeding consensus peak and featureCounts column order. #448 already fixes that call site.
- A one-line sort of the `feature` factor levels before the `dcast` in `plot_homer_annotatepeaks.r` would harden the R script independently of input order. Left out to keep this change small.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes — snapshot impact to be confirmed by CI.
- [x] `CHANGELOG.md` is updated.